### PR TITLE
Updated Version for Pre-Upgrade Check. 

### DIFF
--- a/pre-check/v1.x/README.md
+++ b/pre-check/v1.x/README.md
@@ -14,7 +14,7 @@ We have developed a script to assist in verifying if a cluster is eligible for a
 1. Execute the following command to initiate the check:
 
     ```
-    curl -sLf https://raw.githubusercontent.com/harvester/upgrade-helpers/main/pre-check/v1.1.x/check.sh -o check.sh
+    curl -sLf https://raw.githubusercontent.com/harvester/upgrade-helpers/main/pre-check/v1.x/check.sh -o check.sh
     chmod +x check.sh
     ./check.sh
     ```
@@ -22,30 +22,68 @@ We have developed a script to assist in verifying if a cluster is eligible for a
     The check script will provide an output similar to the following:
 
     ```
-    >>> Check all bundles ready...
-    All Helm bundles are ready.
-    >>> Check the Harvester bundle is ready...
-    The Harvester bundle is ready.
-    >>> Check all nodes are ready...
-    All nodes are ready.
-    >>> Check the CAPI cluster is provisioned...
-    The CAPI cluster is provisioned.
-    >>> Check the CAPI machines are running...
-    The CAPI machines are provisioned.
-    >>> Check Longhorn volumes...
-    All volumes are healthy.
-    >>> Check stale Longhorn volumes...
-    Checking volume longhorn-system/pvc-c664716b-9e3a-4693-a91e-14ede2afb0cd...
-    Checking volume longhorn-system/pvc-ff113f82-702e-46ba-9c0c-bd11ece4ac33...
-    There is no stale Longhorn volume.
-    >>> Check error pods...
-    All pods are OK.
-    All nodes have more than 30GB free space.
+    # ./check.sh -l log.txt
+    ==============================
     
-    All checks pass.
+    Starting Host check...
+    Host Test: Pass
+    
+    ==============================
+    
+    Starting Helm Bundle status check...
+    Helm-Bundles Test: Pass
+    
+    ==============================
+    
+    Starting Harvester Bundle status check...
+    Harvester-Bundles Test: Pass
+    
+    ==============================
+    
+    Starting Node Status check...
+    Node-Status Test: Pass
+    
+    ==============================
+    
+    Starting CAPI Cluster State check...
+    CAPI-Cluster-State Test: Pass
+    
+    ==============================
+    
+    Starting CAPI Machine Count check...
+    CAPI-Machine-Count Test: Pass
+    
+    ==============================
+    
+    Starting CAPI Machine State check...
+    CAPI-Machine-State Test: Pass
+    
+    ==============================
+    
+    Starting Longhorn Volume Health Status check...
+    Longhorn-Volume-Health-Status Test: Pass
+    
+    ==============================
+    
+    Starting Stale Longhorn Volumes check...
+    Stale-Longhorn-Volumes Test: Pass
+    
+    ==============================
+    
+    Starting Pod Status check...
+    Pod-Status Test: Pass
+    
+    ==============================
+    
+    Starting Node Free Space check...
+    Node-Free-Space Test: Pass
+    
+    ==============================
+    
+    All checks have passed.
     ```
 
-    If any checks fail, please refrain from proceeding with the upgrade.
+    If any checks fail, please refrain from proceeding with the upgrade. You can obtain additional information by running the script again with the verbose flag (`./check.sh -v`) or with logging enabled (ie: `./check.sh -l log.txt`). Running the scipt with the `-h` flag can provide additional information and options. 
 
 
 ### Check time is in sync on every node.

--- a/pre-check/v1.x/README.md
+++ b/pre-check/v1.x/README.md
@@ -1,0 +1,54 @@
+# Pre-check scripts before an upgrade
+
+We have developed a script to assist in verifying if a cluster is eligible for a smooth upgrade. Please follow the steps below to utilize the script:
+
+## Usage
+
+1. Log in to a control plane node and switch to the root user:
+
+    ```
+    ssh rancher@<ip>
+    sudo -i
+    ```
+
+1. Execute the following command to initiate the check:
+
+    ```
+    curl -sLf https://raw.githubusercontent.com/harvester/upgrade-helpers/main/pre-check/v1.1.x/check.sh -o check.sh
+    chmod +x check.sh
+    ./check.sh
+    ```
+
+    The check script will provide an output similar to the following:
+
+    ```
+    >>> Check all bundles ready...
+    All Helm bundles are ready.
+    >>> Check the Harvester bundle is ready...
+    The Harvester bundle is ready.
+    >>> Check all nodes are ready...
+    All nodes are ready.
+    >>> Check the CAPI cluster is provisioned...
+    The CAPI cluster is provisioned.
+    >>> Check the CAPI machines are running...
+    The CAPI machines are provisioned.
+    >>> Check Longhorn volumes...
+    All volumes are healthy.
+    >>> Check stale Longhorn volumes...
+    Checking volume longhorn-system/pvc-c664716b-9e3a-4693-a91e-14ede2afb0cd...
+    Checking volume longhorn-system/pvc-ff113f82-702e-46ba-9c0c-bd11ece4ac33...
+    There is no stale Longhorn volume.
+    >>> Check error pods...
+    All pods are OK.
+    All nodes have more than 30GB free space.
+    
+    All checks pass.
+    ```
+
+    If any checks fail, please refrain from proceeding with the upgrade.
+
+
+### Check time is in sync on every node.
+
+If there is no NTP server configured, please log in to each node and check the time is in sync (with `date` command).
+

--- a/pre-check/v1.x/README.md
+++ b/pre-check/v1.x/README.md
@@ -30,6 +30,16 @@ We have developed a script to assist in verifying if a cluster is eligible for a
     
     ==============================
     
+    Starting Certificates check...
+    Certificates Test: Pass
+    
+    ==============================
+    
+    Starting Node Free Space check...
+    Node-Free-Space Test: Pass
+    
+    ==============================
+    
     Starting Helm Bundle status check...
     Helm-Bundles Test: Pass
     
@@ -77,6 +87,11 @@ We have developed a script to assist in verifying if a cluster is eligible for a
     
     Starting Node Free Space check...
     Node-Free-Space Test: Pass
+    
+    ==============================
+    
+    Starting Kubeconfig Secret check...
+    Kubeconfig Secret Test: Pass
     
     ==============================
     

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -478,15 +478,20 @@ check_certs()
 {
     log_info "Starting Certificates check..."
     log_verbose "NOTE: This only checks certs on the current node. Typically certs rotate automatically before they're set to expire when the RKE service restarts or the node is rebooted."
+    # If the cert directory doesn't exist, then we're not on CP node. 
+    if [ ! -d "/var/lib/rancher/rke2/server/tls" ]; then
+        log_info "WARN: The cert directory could not be found. This script should be run from one of the controlplane nodes. Are you sure you're on a CP node?"
+        record_fail "Certificates"
+        return
+    fi
     # Set this to "false"
     expired_certs=1
     # Get a list of all the RKE certs.
     certs_list=$(find /var/lib/rancher/rke2/server/tls/ -name *.crt)
     log_verbose "Found the following certs: ${certs_list}"
     if [[ -z ${certs_list} ]]; then
-        log_info "WARN: No certs found. Are you sure you're on a CP node?"
-        log_info "Certificates Test: Skipped"
-        echo -e "\n==============================\n"
+        log_info "WARN: No certs found to be checked. Are you sure you're on a CP node?"
+        record_fail "Certificates"
         return
     fi
     for cert in $certs_list; do

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -386,7 +386,7 @@ check_free_space()
 #If a log file exists ask users if they want to clear it, or exit. 
 check_log_file()
 {
-    if [ $log_file ]; then
+    if [ -e $log_file ]; then
         read -r -p "The file ${log_file} exists. Are you sure that you want to overwrite/clear the contents of that file? [Y/N] " response
         if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
             echo '' > $log_file

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -72,7 +72,7 @@ log_info()
 
 check_bundles()
 {
-    log_info "Starting helm bundle status check... "
+    log_info "Starting Helm Bundle status check... "
 
     # fleet bundles should be ready
     # except mcc-harvester, which has Modified status in 1.0.3
@@ -80,7 +80,7 @@ check_bundles()
     pending=$(echo "$bundles" | yq '.items | any_c(.metadata.name != "mcc-harvester" and .spec.helm != null and .status.summary.ready == 0)')
 
     if [ "$pending" = "false" ]; then
-      log_verbose "All Helm bundles are ready."
+      log_verbose "All Helm Bundles are ready."
       log_info "Helm-Bundles Test: Pass"
       echo -e "\n==============================\n"
       return
@@ -94,7 +94,7 @@ check_bundles()
 
 check_harvester_bundle()
 {
-    log_info "Starting Harvester bundle status check..."
+    log_info "Starting Harvester Bundle status check..."
 
     current_summary=$(mktemp)
     kubectl get bundles.fleet.cattle.io/mcc-harvester -n fleet-local -o yaml | yq '.status.summary' > $current_summary
@@ -110,7 +110,7 @@ EOF
         record_fail "Harvester-Bundles"
         return
     fi
-    log_verbose "All Harvester bundles are ready."
+    log_verbose "All Harvester Bundles are ready."
     log_info "Harvester-Bundles Test: Pass"
     echo -e "\n==============================\n"
 }
@@ -118,7 +118,7 @@ EOF
 check_nodes()
 {
     local failed="false"
-    log_info "Starting Node-Status check... "
+    log_info "Starting Node Status check... "
 
     # Use a file to store the node state becuase we can't set the global variable inside the piped scope
     # The file is removed in the piped scope if there are not-ready nodes.
@@ -468,5 +468,5 @@ if [ $check_failed -gt 0 ]; then
     log_info "WARN: There are $check_failed failing checks:${failed_check_names}"
     exit 1
 else
-    log_info "All checks have pass."
+    log_info "All checks have passed."
 fi

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -375,7 +375,8 @@ check_free_space()
 {
     log_info "Starting Node Free Space check..."
     prom_ip=$(kubectl get services/rancher-monitoring-prometheus -n cattle-monitoring-system -o yaml | yq '.spec.clusterIP')
-    if [ -z "${prom_ip}" ]; then
+    # Skip the test if the variable is empty or literal "null"
+    if [[ -z "$ip_prom" ||  "$ip_prom" == "null" ]]; then
         log_info "WARN: The script wasn't able to find a valid install of the rancher-monitoring addon, so it could not validate that there is sufficent freespace to complete the upgrade\nTo verify this test manually, log into each of the nodes and run 'df -h /usr/local' to ensure there's more than 30 GB of free space available."
         log_info "Node-Free-Space Test: SKIPPED"
         echo -e "\n==============================\n"

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -431,9 +431,10 @@ check_host()
         echo -e "\n==============================\n"
         return
     fi
-    # Ask the user if they want to contine if the host isn't one of the cp nodes. 
+    # Ask the user if they want to continue if the host isn't one of the cp nodes. 
     if [[ $cp_nodes == *"$(hostname)"* ]]; then
-        log_info "Host Test: Passed"    
+        log_info "Host Test: Pass"
+            echo -e "\n==============================\n"
     else
         log_info "This script is intended to be run from one of the Harvester cluster's Control Plane nodes."
         log_info "It seems like you're running this script from $(hostname) and not one of the following nodes:\n${cp_nodes}"

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -533,7 +533,6 @@ check_machines
 check_volumes
 check_attached_volumes
 check_error_pods
-check_free_space
 check_kubeconfig_secret
 
 if [ $check_failed -gt 0 ]; then

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -334,7 +334,7 @@ check_attached_volumes()
             is_stale=$(kubectl get volumes.longhorn.io/$vol_name -n $vol_namespace -o yaml | yq '.status.kubernetesStatus.workloadsStatus | any_c(.podStatus != "Running")')
             if [ "$is_stale" = "true" ]; then
                 log_info "Volume ${vol_name} is attached, but one or more of its workloads is not running." 
-                log_verbose "$(kubectl get volumes.longhorn.io/$vol_name -n $vol_namespace -o yaml | yq '.status.kubernetesStatus.workloadsStatus')"
+                log_verbose "Details of the workloads:\n$(kubectl get volumes.longhorn.io/$vol_name -n $vol_namespace -o yaml | yq '.status.kubernetesStatus.workloadsStatus')"
                 rm -f $clean_state
             fi
             sleep 0.5

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -1,0 +1,361 @@
+#!/bin/bash -e
+
+usage() {
+ echo "Usage: $0 [OPTIONS]"
+ echo "Options:"
+ echo " -h,	Display this help message"
+ echo " -v,	Enable verbose mode"
+ echo " -l,	Specify path to a log file."
+}
+
+
+while getopts "hvac:k:" flag; do
+ case $flag in
+   h) # Handle the -h flag
+   # Display script help information
+   usage
+   exit 0 
+   ;;
+   v) # Handle the -v flag
+   # Enable verbose mode
+   verbose=true
+   ;;
+   c) # Handle the -c flag with an argument
+   clustername=$OPTARG
+   # Specify the human readable clustername in the slack message. 
+   ;;
+   k) # Handle the -k with an argument
+   kubeconfig=$OPTARG
+   ;;
+   \?)
+   # Handle invalid options
+   usage
+   exit 1
+   ;;
+ esac
+done
+
+#Set failure counter to 0. 
+check_failed=0
+
+record_fail()
+{
+    check_failed=$((check_failed+1))
+}
+
+
+check_bundles()
+{
+    echo ">>> Check all bundles ready..."
+
+    # fleet bundles should be ready
+    # except mcc-harvester, which has Modified status in 1.0.3
+    bundles=$(kubectl get bundles.fleet.cattle.io -A -o yaml)
+    pending=$(echo "$bundles" | yq '.items | any_c(.metadata.name != "mcc-harvester" and .spec.helm != null and .status.summary.ready == 0)')
+
+    if [ "$pending" = "false" ]; then
+      echo "All Helm bundles are ready."
+      return
+    fi
+
+    echo "There are non-ready Helm bundles:"
+    echo "$bundles" | yq '.items[] | select(.spec.helm != null and .status.summary.ready == 0) | .metadata.namespace + "/" + .metadata.name'
+    record_fail
+}
+
+check_harvester_bundle()
+{
+    echo ">>> Check the Harvester bundle is ready..."
+
+    current_summary=$(mktemp)
+    kubectl get bundles.fleet.cattle.io/mcc-harvester -n fleet-local -o yaml | yq '.status.summary' > $current_summary
+
+    expected_summary=$(mktemp)
+cat > $expected_summary <<EOF
+desiredReady: 1
+ready: 1
+EOF
+
+    if ! diff <(yq -P 'sort_keys(..)' $current_summary) <(yq -P 'sort_keys(..)' $expected_summary); then
+        echo "Harvester bundle is not ready!"
+        record_fail
+        return
+    fi
+
+    echo "The Harvester bundle is ready."
+}
+
+check_nodes()
+{
+    local failed="false"
+    echo ">>> Check all nodes are ready..."
+
+    # Use a file to store the node state becuase we can't set the global variable inside the piped scope
+    # The file is removed in the piped scope if there are not-ready nodes.
+    node_ready_state=$(mktemp)
+
+    # nodes should not be cordoned
+    nodes=$(kubectl get nodes -o yaml)
+    unschedulable=$(echo "$nodes" | yq '.items | any_c(.spec.unschedulable == true)')
+
+    if [ "$unschedulable" = "true" ]; then
+        echo "There are unschedulable nodes:"
+        echo "$nodes" | yq '.items[] | select(.spec.unschedulable == true)  | .metadata.name'
+        rm -f $node_ready_state
+    fi
+
+    # nodes should not be tainted
+    tainted=$(echo "$nodes" | yq '.items | any_c(.spec.taints != null)')
+    if [ "$tainted" = "true" ]; then
+        echo "There are tainted nodes:"
+        echo "$nodes" | yq '.items[] | select(.spec.taints != null)  | .metadata.name'
+        rm -f $node_ready_state
+    fi
+
+    # nodes should be ready
+    echo "$nodes" | yq .items[].metadata.name |
+        while read -r node_name; do
+            node_ready=$(kubectl get nodes $node_name -o yaml | yq '.status.conditions | any_c(.type == "Ready" and .status == "True")')
+
+            if [ "$node_ready" = "false" ]; then
+                echo "Node $node_name is not ready!"
+                rm -f $node_ready_state
+            fi
+        done
+
+    if [ -e $node_ready_state ]; then
+        echo "All nodes are ready."
+        rm $node_ready_state
+    else
+        echo "There are non-ready nodes."
+        record_fail
+    fi
+}
+
+check_cluster()
+{
+    echo ">>> Check the CAPI cluster is provisioned..."
+    cluster_phase=$(kubectl get clusters.cluster.x-k8s.io/local -n fleet-local -o yaml | yq '.status.phase')
+
+    # cluster should be in provisioned
+    if [ "$cluster_phase" != "Provisioned" ]; then
+        echo "Cluster is not provisioned ($cluster_phase)"
+        record_fail
+        return
+    fi
+
+    echo "The CAPI cluster is provisioned."
+}
+
+check_machines()
+{
+    local failed="false"
+    echo ">>> Check the CAPI machines count..."
+
+    # machine count should be equal to node counts
+    machine_count=$(kubectl get machines.cluster.x-k8s.io -n fleet-local -o yaml | yq '.items | length')
+    node_count=$(kubectl get nodes -o yaml | yq '.items | length')
+    if [ $machine_count -ne $node_count ]; then
+        echo "CAPI machine count is not equal to node count. There are orphan machines."
+        kubectl get nodes
+        kubectl get machines.cluster.x-k8s.io -n fleet-local
+        record_fail
+    else
+        echo "CAPI machine count is equal to node count."
+    fi
+
+    echo ">>> Check the CAPI machines are running..."
+
+    # Use a file to store the machine state becuase we can't set the global variable inside the piped scope
+    # The file is removed in the piped scope if there are not-ready machines.
+    machine_ready_state=$(mktemp)
+
+    # all machines need to be provisioned
+    kubectl get machines.cluster.x-k8s.io -n fleet-local -o yaml | yq '.items[].metadata.name' |
+        while read -r machine_name; do
+            machine_phase=$(kubectl get machines.cluster.x-k8s.io/$machine_name -n fleet-local -o yaml | yq '.status.phase')
+
+            if [ "$machine_phase" != "Running" ]; then
+                echo "CAPI machine $machine_name phase is not Running ($machine_phase)."
+                rm -f $machine_ready_state
+            fi
+        done
+
+    if [ -e $machine_ready_state  ]; then
+        echo "The CAPI machines are provisioned."
+        rm $machine_ready_state
+    else
+        echo "There are non-ready CAPI machines."
+        record_fail
+    fi
+}
+
+check_volumes()
+{
+    echo ">>> Check Longhorn volumes..."
+
+    node_count=$(kubectl get nodes -o yaml | yq '.items | length')
+
+    if [ $node_count -eq 1 ]; then
+        echo "Skip checking for single node cluster."
+        return
+    fi
+
+    # Use a file to store the healthy state becuase we can't set the global variable inside the piped scope
+    # The file is removed in the piped scope if there are any degraded volumes.
+    healthy_state=$(mktemp)
+
+    # For each running engine and its volume
+    kubectl get engines.longhorn.io -n longhorn-system -o json |
+        jq -r '.items | map(select(.status.currentState == "running")) | map(.metadata.name + " " + .metadata.labels.longhornvolume) | .[]' | {
+            while read -r lh_engine lh_volume; do
+                echo checking running engine "${lh_engine}..."
+
+                if [ $node_count -gt 2 ];then
+                    volume_json=$(kubectl get volumes.longhorn.io/$lh_volume -n longhorn-system -o json)
+                    # single-replica volumes should be handled exclusively
+                    volume_replicas=$(echo $volume_json | jq -r '.spec.numberOfReplicas')
+                    if [ $volume_replicas -eq 1 ]; then
+                        echo "Volume $lh_volume is a single-replica volume. Please consider shutting down the corresponding workload or adjusting its replica count before upgrading."
+                        rm -f $healthy_state
+                    else
+                        robustness=$(echo $volume_json | jq -r '.status.robustness')
+                        if [ "$robustness" = "healthy" ]; then
+                            echo "Volume $lh_volume is healthy."
+                        else
+                            echo "Volume $lh_volume is degraded."
+                            rm -f $healthy_state
+                        fi
+                    fi
+                else
+                    # two node situation, make sure maximum two replicas are healthy
+                    expected_replicas=2
+
+                    # replica 1 case
+                    volume_replicas=$(kubectl get volumes.longhorn.io/$lh_volume -n longhorn-system -o jsonpath='{.spec.numberOfReplicas}')
+                    if [ $volume_replicas -eq 1 ]; then
+                        expected_replicas=1
+                    fi
+
+                    ready_replicas=$(kubectl get engines.longhorn.io/$lh_engine -n longhorn-system -o json |
+                                    jq -r '.status.replicaModeMap | to_entries | map(select(.value == "RW")) | length')
+                    if [ $ready_replicas -ge $expected_replicas ]; then
+                        echo "Volume $lh_volume is healthy."
+                    else
+                        echo "Volume $lh_volume is degraded."
+                        rm -f $healthy_state
+                    fi
+                fi
+                sleep 0.5
+            done
+        }
+
+    if [ -e $healthy_state ]; then
+        echo "All volumes are healthy."
+        rm $healthy_state
+    else
+        echo "There are volumes that need your attention!"
+        record_fail
+    fi
+}
+
+# https://github.com/harvester/harvester/issues/3648
+check_attached_volumes()
+{
+    echo ">>> Check stale Longhorn volumes..."
+
+    # Use a file to store the clean state becuase we can't set the global variable inside the piped scope
+    # The file is removed in the piped scope if any volume is stale.
+    clean_state=$(mktemp)
+
+    volumes=$(kubectl get volumes.longhorn.io -A -o yaml)
+    # for each attached volume
+    echo "$volumes" | yq '.items[] | select(.status.state == "attached") | .metadata.namespace + " " + .metadata.name' | {
+        while read -r vol_namespace vol_name; do
+            echo "Checking volume $vol_namespace/$vol_name..."
+
+            # check .status.kubernetesStatus.workloadStatus is nil
+            workloads=$(kubectl get volumes.longhorn.io/$vol_name -n $vol_namespace -o yaml | yq '.status.kubernetesStatus.workloadsStatus | length')
+            if [ "$workloads" = "0" ]; then
+                echo "Volume $vol_namespace/$vol_name is attached but has no workload."
+                rm -f $clean_state
+                continue
+            fi
+
+            # check .status.kubernetesStatus.workloadStatus has non-running workload. e.g.,
+            # workloadsStatus:
+            #   - podName: virt-launcher-ubuntu-h9cfq
+            #     podStatus: Succeeded
+            #     workloadName: ubuntu
+            #     workloadType: VirtualMachineInstance
+            is_stale=$(kubectl get volumes.longhorn.io/$vol_name -n $vol_namespace -o yaml | yq '.status.kubernetesStatus.workloadsStatus | any_c(.podStatus != "Running")')
+            if [ "$is_stale" = "true" ]; then
+                echo "Volume $vol_namespace/$vol_name is attached but its workload is not running." 
+                rm -f $clean_state
+            fi
+            sleep 0.5
+        done
+    }
+
+    if [ -e $clean_state ]; then
+        echo "There is no stale Longhorn volume."
+        rm $clean_state
+    else
+        echo "There are stale volumes."
+        record_fail
+    fi
+}
+
+check_error_pods()
+{
+    echo ">>> Check error pods..."
+
+    pods=$(kubectl get pods -A -o yaml)
+    no_ok=$(echo "$pods" | yq '.items | any_c(.status.phase != "Running" and .status.phase != "Succeeded")')
+
+    if [ "$no_ok" = "false" ]; then
+        echo "All pods are OK."
+        return
+    fi
+
+    echo "There are non-ready pods:"
+    echo "$pods" | yq '.items[] | select(.status.phase != "Running" and .status.phase != "Succeeded") | .metadata.namespace + "/" + .metadata.name'
+    record_fail
+}
+
+# only works in Harvester nodes
+check_free_space()
+{
+    prom_ip=$(kubectl get services/rancher-monitoring-prometheus -n cattle-monitoring-system -o yaml | yq -e '.spec.clusterIP')
+    result=$(curl -sg "http://$prom_ip:9090/api/v1/query?query=node_filesystem_avail_bytes{mountpoint=\"/usr/local\"}<32212254720" | jq '.data.result')
+
+    length=$(echo "$result" | jq 'length')
+
+    if [ "$length" == "0" ]; then
+        echo "All nodes have more than 30GB free space."
+        return
+    fi
+
+    echo "Nodes doesn't have enough free space:"
+    echo "$result" | jq -r '.[].metric.instance'
+    record_fail
+}
+
+check_bundles
+check_harvester_bundle
+check_nodes
+check_cluster
+check_machines
+check_volumes
+check_attached_volumes
+check_error_pods
+check_free_space
+
+if [ $check_failed -gt 0 ]; then
+    echo ""
+    echo "There are $check_failed failing checks!"
+    exit 1
+else
+    echo ""
+    echo "All checks pass."
+fi

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -464,7 +464,7 @@ check_error_pods
 check_free_space
 
 if [ $check_failed -gt 0 ]; then
-    log_info "WARN: There are $check_failed failing checks: ${failed_check_names}"
+    log_info "WARN: There are $check_failed failing checks:${failed_check_names}"
     exit 1
 else
     log_info "All checks have pass."

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -456,7 +456,7 @@ check_kubeconfig_secret()
     # Get all the secrets with the label selector.
     secrets=$(kubectl get secrets -n fleet-local --selector cluster.x-k8s.io/cluster-name=local)
     # If  local-kubeconfig is in the list, the test passed.
-    if [[ $secrets == *"local-kubecoonfig"* ]]; then
+    if [[ $secrets == *"local-kubeconfig"* ]]; then
         log_info "Kubeconfig Secret Test: Pass"
         echo -e "\n==============================\n"
     else

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -334,7 +334,7 @@ check_attached_volumes()
             is_stale=$(kubectl get volumes.longhorn.io/$vol_name -n $vol_namespace -o yaml | yq '.status.kubernetesStatus.workloadsStatus | any_c(.podStatus != "Running")')
             if [ "$is_stale" = "true" ]; then
                 log_info "Volume ${vol_name} is attached, but one or more of its workloads is not running." 
-                log_verbose "${workloads}"
+                log_verbose "$(kubectl get volumes.longhorn.io/$vol_name -n $vol_namespace -o yaml | yq '.status.kubernetesStatus.workloadsStatus')"
                 rm -f $clean_state
             fi
             sleep 0.5

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -377,7 +377,7 @@ check_free_space()
     prom_ip=$(kubectl get services/rancher-monitoring-prometheus -n cattle-monitoring-system -o yaml | yq '.spec.clusterIP')
     # Skip the test if the variable is empty or literal "null"
     if [[ -z "$ip_prom" ||  "$ip_prom" == "null" ]]; then
-        log_info "WARN: The script wasn't able to find a valid install of the rancher-monitoring addon, so it could not validate that there is sufficent freespace to complete the upgrade\nTo verify this test manually, log into each of the nodes and run 'df -h /usr/local' to ensure there's more than 30 GB of free space available."
+        log_info "WARN: The script wasn't able to find a valid install of the rancher-monitoring addon, so it could not validate that there is sufficent freespace to complete the upgrade. To verify this test manually, log into each of the nodes and run 'df -h /usr/local' to ensure there's more than 30 GB of free space available."
         log_info "Node-Free-Space Test: SKIPPED"
         echo -e "\n==============================\n"
         return

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -400,7 +400,7 @@ check_free_space()
 #If a log file exists ask users if they want to clear it, or exit. 
 check_log_file()
 {
-    if [ -e $log_file ]; then
+    if [ -e "$log_file" ]; then
         # Just clear the file if run with -y
         if [ "$answer" = true ]; then
             echo -e "[$(date +'%Y-%m-%d %H:%M:%S')] Cleared Previous Log File" > "$log_file"

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -5,27 +5,23 @@ usage() {
  echo "Options:"
  echo " -h,	Display this help message"
  echo " -v,	Enable verbose mode"
- echo " -l,	Specify path to a log file."
+ echo " -o,	Specify path to a log file."
 }
 
 
-while getopts "hvac:k:" flag; do
+while getopts "hvl:k:" flag; do
  case $flag in
    h) # Handle the -h flag
    # Display script help information
    usage
    exit 0 
    ;;
+   l) # Handle the -l with an argument
+   log_file=$OPTARG
+   ;;
    v) # Handle the -v flag
    # Enable verbose mode
    verbose=true
-   ;;
-   c) # Handle the -c flag with an argument
-   clustername=$OPTARG
-   # Specify the human readable clustername in the slack message. 
-   ;;
-   k) # Handle the -k with an argument
-   kubeconfig=$OPTARG
    ;;
    \?)
    # Handle invalid options
@@ -43,12 +39,35 @@ record_fail()
 {
     check_failed=$((check_failed+1))
     failed_check_names=$((failed_check_names+"$1 "))
+    log_info "${1} Test: Failed"
+    echo -e "==============================\n\n"
 }
+
+#Log verbose messages, but don't echo them unless the -v flag is used.
+log_verbose()
+{
+    if [ $log_file ]; then
+        echo "[$(date +'%Y-%m-%d %H:%M:%S')] ${1}" >> "$log_file"
+    fi
+    if [ "$verbose" = true ]; then 
+        echo "${1}"
+    fi
+}
+
+#Log Info/Error Messages and always echo them. 
+log_info()
+{
+    if [ $log_file ]; then
+        echo "[$(date +'%Y-%m-%d %H:%M:%S')] ${1}" >> "$log_file"
+    fi
+    echo "${1}"
+}
+
 
 
 check_bundles()
 {
-    echo ">>> Check all bundles ready..."
+    log_info "Starting helm bundle status check... "
 
     # fleet bundles should be ready
     # except mcc-harvester, which has Modified status in 1.0.3
@@ -56,18 +75,21 @@ check_bundles()
     pending=$(echo "$bundles" | yq '.items | any_c(.metadata.name != "mcc-harvester" and .spec.helm != null and .status.summary.ready == 0)')
 
     if [ "$pending" = "false" ]; then
-      echo "All Helm bundles are ready."
+      log_verbose "All Helm bundles are ready."
+      log_info "Helm-Bundles Test: Pass"
+      echo -e "==============================\n"
       return
     fi
-
-    echo "There are non-ready Helm bundles:"
-    echo "$bundles" | yq '.items[] | select(.spec.helm != null and .status.summary.ready == 0) | .metadata.namespace + "/" + .metadata.name'
+    # These are failures so send them to the info log
+    log_info "There are non-ready Helm bundles:"
+    log_info "$(echo "$bundles" | yq '.items[] | select(.spec.helm != null and .status.summary.ready == 0) | .metadata.namespace + "/" + .metadata.name')"
+    echo -e "\n"
     record_fail "Helm-Bundles"
 }
 
 check_harvester_bundle()
 {
-    echo ">>> Check the Harvester bundle is ready..."
+    log_info "Starting Harvester bundle status check..."
 
     current_summary=$(mktemp)
     kubectl get bundles.fleet.cattle.io/mcc-harvester -n fleet-local -o yaml | yq '.status.summary' > $current_summary
@@ -79,18 +101,19 @@ ready: 1
 EOF
 
     if ! diff <(yq -P 'sort_keys(..)' $current_summary) <(yq -P 'sort_keys(..)' $expected_summary); then
-        echo "Harvester bundle is not ready!"
+        log_info "Harvester bundle is not ready!"
         record_fail "Harvester-Bundles"
         return
     fi
-
-    echo "The Harvester bundle is ready."
+    log_verbose "All Harvester bundles are ready."
+    log_info "Harvester-Bundles Test: Pass"
+    echo -e "==============================\n"
 }
 
 check_nodes()
 {
     local failed="false"
-    echo ">>> Check all nodes are ready..."
+    log_info "Starting Node-Status check... "
 
     # Use a file to store the node state becuase we can't set the global variable inside the piped scope
     # The file is removed in the piped scope if there are not-ready nodes.
@@ -101,16 +124,16 @@ check_nodes()
     unschedulable=$(echo "$nodes" | yq '.items | any_c(.spec.unschedulable == true)')
 
     if [ "$unschedulable" = "true" ]; then
-        echo "There are unschedulable nodes:"
-        echo "$nodes" | yq '.items[] | select(.spec.unschedulable == true)  | .metadata.name'
+        log_info "There are unschedulable nodes:"
+        log_info "$(echo "$nodes" | yq '.items[] | select(.spec.unschedulable == true)  | .metadata.name')"
         rm -f $node_ready_state
     fi
 
     # nodes should not be tainted
     tainted=$(echo "$nodes" | yq '.items | any_c(.spec.taints != null)')
     if [ "$tainted" = "true" ]; then
-        echo "There are tainted nodes:"
-        echo "$nodes" | yq '.items[] | select(.spec.taints != null)  | .metadata.name'
+        log_info "There are tainted nodes:"
+        log_info "$(echo "$nodes" | yq '.items[] | select(.spec.taints != null)  | .metadata.name')"
         rm -f $node_ready_state
     fi
 
@@ -118,55 +141,60 @@ check_nodes()
     echo "$nodes" | yq .items[].metadata.name |
         while read -r node_name; do
             node_ready=$(kubectl get nodes $node_name -o yaml | yq '.status.conditions | any_c(.type == "Ready" and .status == "True")')
-
             if [ "$node_ready" = "false" ]; then
-                echo "Node $node_name is not ready!"
+                log_info "Node $node_name is not ready!"
                 rm -f $node_ready_state
             fi
         done
 
     if [ -e $node_ready_state ]; then
-        echo "All nodes are ready."
+        log_verbose "All nodes are ready."
+        log_info "Node-Status Test: Pass"
+        echo -e "==============================\n"
         rm $node_ready_state
     else
-        echo "There are non-ready nodes."
+        log_verbose "There are non-ready nodes."
         record_fail "Node-Status"
     fi
 }
 
 check_cluster()
 {
-    echo ">>> Check the CAPI cluster is provisioned..."
+    log_info "Starting CAPI Cluster State check..."
     cluster_phase=$(kubectl get clusters.cluster.x-k8s.io/local -n fleet-local -o yaml | yq '.status.phase')
 
     # cluster should be in provisioned
     if [ "$cluster_phase" != "Provisioned" ]; then
-        echo "Cluster is not provisioned ($cluster_phase)"
+        log_info "Cluster is not provisioned ($cluster_phase)"
         record_fail "CAPI-Cluster-State"
         return
     fi
 
-    echo "The CAPI cluster is provisioned."
+    log_verbose "The CAPI cluster is provisioned."
+    log_info "CAPI-Cluster-State Test: Pass"
+    echo -e "==============================\n"
 }
 
 check_machines()
 {
     local failed="false"
-    echo ">>> Check the CAPI machines count..."
+    log_info "Starting CAPI Machine Count check..."
 
     # machine count should be equal to node counts
     machine_count=$(kubectl get machines.cluster.x-k8s.io -n fleet-local -o yaml | yq '.items | length')
     node_count=$(kubectl get nodes -o yaml | yq '.items | length')
     if [ $machine_count -ne $node_count ]; then
-        echo "CAPI machine count is not equal to node count. There are orphan machines."
-        kubectl get nodes
-        kubectl get machines.cluster.x-k8s.io -n fleet-local
+        log_info "CAPI machine count (${machine_count}) is not equal to node count (${node_count}). There are orphan machines:"
+        log_info "$(kubectl get nodes)"
+        log_info "$(kubectl get machines.cluster.x-k8s.io -n fleet-local)"
         record_fail "CAPI-Machine-Count"
     else
-        echo "CAPI machine count is equal to node count."
+        log_verbose "CAPI machine count is equal to node count."
+        log_info "CAPI-Machine-Count Test: Pass"
+        echo -e "==============================\n"
     fi
 
-    echo ">>> Check the CAPI machines are running..."
+    log_info "Starting CAPI Machine State check..."
 
     # Use a file to store the machine state becuase we can't set the global variable inside the piped scope
     # The file is removed in the piped scope if there are not-ready machines.
@@ -178,28 +206,31 @@ check_machines()
             machine_phase=$(kubectl get machines.cluster.x-k8s.io/$machine_name -n fleet-local -o yaml | yq '.status.phase')
 
             if [ "$machine_phase" != "Running" ]; then
-                echo "CAPI machine $machine_name phase is not Running ($machine_phase)."
+                log_info "CAPI machine $machine_name phase is not Running but is: ($machine_phase)."
                 rm -f $machine_ready_state
             fi
         done
 
     if [ -e $machine_ready_state  ]; then
-        echo "The CAPI machines are provisioned."
+        log_verbose "The CAPI machines are provisioned."
+        log_info "CAPI-Machine-State Test: Pass"
         rm $machine_ready_state
     else
-        echo "There are non-ready CAPI machines."
+        log_verbose "There are non-ready CAPI machines."
         record_fail "CAPI-Machine-State"
     fi
 }
 
 check_volumes()
 {
-    echo ">>> Check Longhorn volumes..."
+    log_info "Starting Longhorn Volume Health Status check..."
 
     node_count=$(kubectl get nodes -o yaml | yq '.items | length')
 
     if [ $node_count -eq 1 ]; then
-        echo "Skip checking for single node cluster."
+        log_info "Skip checking for single node cluster."
+        log_info "Longhorn-Volume-Health-Status Test: Skipped"
+        echo -e "==============================\n"
         return
     fi
 
@@ -211,29 +242,30 @@ check_volumes()
     kubectl get engines.longhorn.io -n longhorn-system -o json |
         jq -r '.items | map(select(.status.currentState == "running")) | map(.metadata.name + " " + .metadata.labels.longhornvolume) | .[]' | {
             while read -r lh_engine lh_volume; do
-                echo checking running engine "${lh_engine}..."
+                log_verbose "Checking running engine: ${lh_engine}"
 
                 if [ $node_count -gt 2 ];then
                     volume_json=$(kubectl get volumes.longhorn.io/$lh_volume -n longhorn-system -o json)
                     # single-replica volumes should be handled exclusively
                     volume_replicas=$(echo $volume_json | jq -r '.spec.numberOfReplicas')
                     if [ $volume_replicas -eq 1 ]; then
-                        echo "Volume $lh_volume is a single-replica volume. Please consider shutting down the corresponding workload or adjusting its replica count before upgrading."
+                        log_info "Volume ${lh_volume} is a single-replica volume. Please consider shutting down the corresponding workload or adjusting its replica count before upgrading."
                         rm -f $healthy_state
                     else
                         robustness=$(echo $volume_json | jq -r '.status.robustness')
                         if [ "$robustness" = "healthy" ]; then
-                            echo "Volume $lh_volume is healthy."
+                            log_verbose "Volume ${lh_volume} is healthy."
                         else
-                            echo "Volume $lh_volume is degraded."
+                            log_info "Degraded Longhorn Volume found: ${lh_volume}"
                             rm -f $healthy_state
                         fi
                     fi
                 else
-                    # two node situation, make sure maximum two replicas are healthy
+                    # This is a two node situation since we skip this in single nodes and the previous section is 3 or more. 
+                    # Make sure maximum two replicas are healthy.
                     expected_replicas=2
 
-                    # replica 1 case
+                    # Replica 1 case
                     volume_replicas=$(kubectl get volumes.longhorn.io/$lh_volume -n longhorn-system -o jsonpath='{.spec.numberOfReplicas}')
                     if [ $volume_replicas -eq 1 ]; then
                         expected_replicas=1
@@ -242,9 +274,9 @@ check_volumes()
                     ready_replicas=$(kubectl get engines.longhorn.io/$lh_engine -n longhorn-system -o json |
                                     jq -r '.status.replicaModeMap | to_entries | map(select(.value == "RW")) | length')
                     if [ $ready_replicas -ge $expected_replicas ]; then
-                        echo "Volume $lh_volume is healthy."
+                        log_verbose "Volume ${lh_volume} is healthy."
                     else
-                        echo "Volume $lh_volume is degraded."
+                        log_info "Degraded Longhorn Volume found: ${lh_volume}"
                         rm -f $healthy_state
                     fi
                 fi
@@ -253,10 +285,12 @@ check_volumes()
         }
 
     if [ -e $healthy_state ]; then
-        echo "All volumes are healthy."
+        log_verbose "All volumes are healthy."
+        log_info "Longhorn-Volume-Health-Status Test: Pass"
+        echo -e "==============================\n"
         rm $healthy_state
     else
-        echo "There are volumes that need your attention!"
+        log_info "There are volumes that need your attention!"
         record_fail "Longhorn-Volume-Health-Status"
     fi
 }
@@ -264,7 +298,7 @@ check_volumes()
 # https://github.com/harvester/harvester/issues/3648
 check_attached_volumes()
 {
-    echo ">>> Check stale Longhorn volumes..."
+    log_info "Starting Stale Longhorn Volumes check..."
 
     # Use a file to store the clean state becuase we can't set the global variable inside the piped scope
     # The file is removed in the piped scope if any volume is stale.
@@ -274,12 +308,12 @@ check_attached_volumes()
     # for each attached volume
     echo "$volumes" | yq '.items[] | select(.status.state == "attached") | .metadata.namespace + " " + .metadata.name' | {
         while read -r vol_namespace vol_name; do
-            echo "Checking volume $vol_namespace/$vol_name..."
+            log_verbose "Checking volume: ${vol_namespace}/${vol_name}"
 
             # check .status.kubernetesStatus.workloadStatus is nil
             workloads=$(kubectl get volumes.longhorn.io/$vol_name -n $vol_namespace -o yaml | yq '.status.kubernetesStatus.workloadsStatus | length')
             if [ "$workloads" = "0" ]; then
-                echo "Volume $vol_namespace/$vol_name is attached but has no workload."
+                log_info "Volume $vol_namespace/$vol_name is attached but has no workload."
                 rm -f $clean_state
                 continue
             fi
@@ -292,7 +326,7 @@ check_attached_volumes()
             #     workloadType: VirtualMachineInstance
             is_stale=$(kubectl get volumes.longhorn.io/$vol_name -n $vol_namespace -o yaml | yq '.status.kubernetesStatus.workloadsStatus | any_c(.podStatus != "Running")')
             if [ "$is_stale" = "true" ]; then
-                echo "Volume $vol_namespace/$vol_name is attached but its workload is not running." 
+                log_info "Volume ${vol_namespace}/${vol_name} is attached but its workload is not running." 
                 rm -f $clean_state
             fi
             sleep 0.5
@@ -300,32 +334,36 @@ check_attached_volumes()
     }
 
     if [ -e $clean_state ]; then
-        echo "There is no stale Longhorn volume."
+        log_verbose "There is no stale Longhorn volume."
         rm $clean_state
+        log_info "Stale-Longhorn-Volumes Test: Pass"
+        echo -e "==============================\n"
     else
-        echo "There are stale volumes."
+        log_st "There are stale volumes."
         record_fail "Stale-Longhorn-Volumes"
     fi
 }
 
 check_error_pods()
 {
-    echo ">>> Check error pods..."
+    log_info "Starting Pod Status check..."
 
     pods=$(kubectl get pods -A -o yaml)
     no_ok=$(echo "$pods" | yq '.items | any_c(.status.phase != "Running" and .status.phase != "Succeeded")')
 
     if [ "$no_ok" = "false" ]; then
-        echo "All pods are OK."
+        logging_verbose "All pods are OK."
+        log_info "Pod-Status Test: Pass"
+        echo -e "==============================\n"
         return
     fi
 
-    echo "There are non-ready pods:"
-    echo "$pods" | yq '.items[] | select(.status.phase != "Running" and .status.phase != "Succeeded") | .metadata.namespace + "/" + .metadata.name'
+    log_info "There are non-ready pods:"
+    log_info "$(echo "$pods" | yq '.items[] | select(.status.phase != "Running" and .status.phase != "Succeeded") | .metadata.namespace + "/" + .metadata.name')"
     record_fail "Pod-Status"
 }
 
-# only works in Harvester nodes
+# Only works in Harvester nodes.
 check_free_space()
 {
     prom_ip=$(kubectl get services/rancher-monitoring-prometheus -n cattle-monitoring-system -o yaml | yq -e '.spec.clusterIP')
@@ -334,14 +372,43 @@ check_free_space()
     length=$(echo "$result" | jq 'length')
 
     if [ "$length" == "0" ]; then
-        echo "All nodes have more than 30GB free space."
+        log_verbose "All nodes have more than 30GB free space."
+        log_info "Node-Free-Space Test: Pass"
+        echo -e "==============================\n"
         return
     fi
 
-    echo "Nodes doesn't have enough free space:"
-    echo "$result" | jq -r '.[].metric.instance'
+    log_info "Nodes doesn't have enough free space:"
+    log_info "$(echo "$result" | jq -r '.[].metric.instance')"
     record_fail "Node-Free-Space"
 }
+
+#If a log file exists ask users if they want to clear it, or exit. 
+check_log_file()
+{
+    if [ $log_file ]; then
+        read -r -p "The file ${log_file} exists. Are you sure that you want to overwrite/clear the contents of that file? [Y/N] " response
+        if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+            echo '' > $log_file
+        else
+            echo -e "Choose a different filename for the log flag (-l) or move/rename the file and run the script again. \nExiting."
+            exit 1
+        fi
+    fi
+}
+
+check_log_file
+
+log_verbose "Script has started"
+
+log_info "This script is intended to be run from one of the Harvester cluster's Control Plane nodes."
+log_info "You should stop the script (Ctrl+C) and run it from there if this is not the case."
+# Pause for humans.
+sleep 2
+
+log_verbose "The OS release is: $(awk -F= '$1=="PRETTY_NAME" { print $2 ;}' /etc/os-release)"
+
+exit 0
 
 check_bundles
 check_harvester_bundle
@@ -354,10 +421,8 @@ check_error_pods
 check_free_space
 
 if [ $check_failed -gt 0 ]; then
-    echo ""
-    echo "There are $check_failed failing checks!"
+    log_info "WARN: There are $check_failed failing checks: ${failed_check_names}"
     exit 1
 else
-    echo ""
-    echo "All checks pass."
+    log_info "All checks have pass."
 fi

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -425,16 +425,15 @@ check_host()
     log_verbose "The hostname is: $(hostname)"
     log_verbose "Controlplane nodes are:\n${cp_nodes}"
     log_verbose "The OS release is: $(awk -F= '$1=="PRETTY_NAME" { print $2 ;}' /etc/os-release)"
-    # Just continue if -y was supplied
-    if [  "$answer" = true ]; then
-        log_info "Host Test: Skipped"
-        echo -e "\n==============================\n"
-        return
-    fi
     # Ask the user if they want to continue if the host isn't one of the cp nodes. 
     if [[ $cp_nodes == *"$(hostname)"* ]]; then
         log_info "Host Test: Pass"
             echo -e "\n==============================\n"
+    # Just continue if -y was supplied
+    elif [  "$answer" = true ]; then
+        log_info "Host Test: Skipped"
+        echo -e "\n==============================\n"
+        return
     else
         log_info "This script is intended to be run from one of the Harvester cluster's Control Plane nodes."
         log_info "It seems like you're running this script from $(hostname) and not one of the following nodes:\n${cp_nodes}"


### PR DESCRIPTION
There was some versioning for the update `check.sh` that seemed to be lagging behind, but after talking with support it seems like it's good for all the other versions. I added a new folder with a `1.x` since it seems to be expected that it'll continue to work for 1.4 as well. A few other things this PR adds: 

- A check to see if the host running the script matches the name of one of the Control-Plane Nodes (as req in the README.md) 
- A check to see if the `local-kubeconfig` secret in the `fleet-local` namespace is missing a label that causes a [known issue](https://docs.harvesterhci.io/v1.3/upgrade/v1-2-2-to-v1-3-1) in the 1.2.2 > 1.3.1 upgrade. 
- A check to see if internal certs have expired that can cause the upgrade to get stuck or fail ([known issue](https://github.com/harvester/harvester/issues/3863))
- Bigger formatting with spaces  between tests to help with readability. (personally was having trouble groking the output)
- Added runtime flags
- Logging  functions and a flag (`-l /path/to/file.log`) will generate a log file. 
- Fixed a few grammatical statements. 
- Moved some of the printed lines to verbose (`-v` flag) messages to help highlight/emphasize more important information (errors and failures).  (Note logs, if enabled, always contain verbose messages) 
- Updated README.md with new example and additional information. 
- Gives a summary on which sections failed at the conclusion.

My feeling won't get hurt at all if you change/alter any parts of the PR. I'm also happy to make the changes myself if you identify any. 