### PR TITLE
Improve output and ignore not found volume

### DIFF
--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -251,7 +251,11 @@ check_volumes()
             while read -r lh_engine lh_volume; do
                 log_verbose "Checking engine: ${lh_engine}"
 
-                volume_json=$(kubectl get volumes.longhorn.io/$lh_volume -n longhorn-system -o json)
+                volume_json=$(kubectl get volumes.longhorn.io/$lh_volume -n longhorn-system -o json 2>/dev/null || true)
+                if [ -z "$volume_json" ]; then
+                    log_info "Volume ${lh_volume} not found."
+                    continue
+                fi
                 # single-replica volumes should be handled exclusively
                 volume_replicas=$(echo $volume_json | jq -r '.spec.numberOfReplicas')
                 if [ $volume_replicas -eq 1 ]; then

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -273,8 +273,8 @@ check_volumes()
                         log_verbose "Volume ${lh_volume} is healthy."
                     elif [ "$state" = "detached" ]; then
                         replica_count=$(kubectl get replicas -n longhorn-system -l longhornvolume=$lh_volume -o json | jq '.items | length')
-                        if [ $replica_count -le 1 ]; then
-                            log_info "Degraded Longhorn Volume found: ${lh_volume}"
+                        if [ $replica_count -lt $volume_replicas ]; then
+                            log_info "Detached Longhorn Volume: ${lh_volume} w/o enough replicas"
                             rm -f $healthy_state
                         else
                             log_info "Detached Longhorn Volume found: ${lh_volume}"


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/7655

## Test steps

### Node has not enough space

1. Create a cluster.
2. Make one of node uses more than 85% usage.
3. Run the check script and get following output.
```
> ./pre-check/v1.x/check.sh
...
Starting Node Free Space check...
Node harvester-node-0 doesn't have enough free space.
Used: 124 GB
Capacity: 146 GB
There are nodes without enough free space to load new images!
Node-Free-Space Test: Failed
...
```

### Nonexistent volume doesn't break the script

1. Create multiple volumes.
2. When you see `Starting Longhorn Volume Health Status check...`, remove one volume.
3. The script can finish without error.

### Show detached volumes

1. Create a 1-node cluster.
2. Create a VM.
3. Stop the VM.
4. Add a new node to the cluster.
5. Run the script and get following output.
```
> ./pre-check/v1.x/check.sh
...
Starting Longhorn Volume Health Status check...
Degraded Longhorn Volume found: pvc-b6fe41b6-a03e-4846-88c1-32b051062ef0
There are volumes that need your attention!
Longhorn-Volume-Health-Status Test: Failed
...
```
6. Start the VM again.
7. After there are two running replicas, stop the VM.
8. Run the script and get following output.
```
> ./pre-check/v1.x/check.sh
...
Starting Longhorn Volume Health Status check...
Detached Longhorn Volume found: pvc-b6fe41b6-a03e-4846-88c1-32b051062ef0
Longhorn-Volume-Health-Status Test: Pass
...
```