### PR TITLE
Feat: Longhorn Backing Images Check

### DIFF
--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -274,10 +274,10 @@ check_volumes()
                     elif [ "$state" = "detached" ]; then
                         replica_count=$(kubectl get replicas -n longhorn-system -l longhornvolume=$lh_volume -o json | jq '.items | length')
                         if [ $replica_count -lt $volume_replicas ]; then
-                            log_info "Detached Longhorn Volume: ${lh_volume} w/o enough replicas"
+                            log_info "Detached Longhorn Volume: ${lh_volume} should have ${volume_replicas} replicas, but only has ${replica_count}."
                             rm -f $healthy_state
                         else
-                            log_info "Detached Longhorn Volume found: ${lh_volume}"
+                            log_verbose "Detached Longhorn Volume found: ${lh_volume}"
                         fi
                     else
                         log_info "Degraded Longhorn Volume found: ${lh_volume}"

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -411,10 +411,10 @@ check_free_space()
 
                 # New images usage will be around 13GB (13 * 1024 * 1024 * 1024 bytes).
                 # If used space + 13GB is more than 85% of the capacity, then the node doesn't have enough free space.
-                if [ $(echo "scale=2; ($used_bytes + 13958643712) / $capacity_bytes > 0.85" | bc) -eq 1 ]; then
+                if awk -v used="$used_bytes" -v cap="$capacity_bytes" 'BEGIN {exit !(((used + 13958643712) / cap) > 0.85)}'; then
                     log_info "Node ${node_name} doesn't have enough free space."
-                    log_info "Used: $(echo "$used_bytes / 1024 / 1024 / 1024" | bc) GB"
-                    log_info "Capacity: $(echo "$capacity_bytes / 1024 / 1024 / 1024" | bc) GB"
+                    log_info "Used: $(awk -v used="$used_bytes" 'BEGIN {printf "%.2f", used/1024/1024/1024}') GB"
+                    log_info "Capacity: $(awk -v cap="$capacity_bytes" 'BEGIN {printf "%.2f", cap/1024/1024/1024}') GB"
                     rm -f $disk_space_state
                 fi
             done


### PR DESCRIPTION
In the event the `.spec.minNumberOfCopies` for `backingImages` is set to `0`, an upgrade could potentially cause data loss for the cluster. This check throws a warning if the min copies is less than `3` and a failure if it's set to `0`. 

I also noticed that some of the evaluations for temp files could use double quotes to ensure we don't get false positives. Additionally gave some messages additional details, and moved standard "ok" messages to the verbose log for clarity/brevity. 