### PR TITLE
fix: skip Longhorn backing image check for versions earlier than v1.4.0

### DIFF
--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -592,6 +592,24 @@ check_backup_target()
 check_images()
 {
     log_info "Starting Longhorn Backing Images check..."
+
+    version=$(kubectl get settings.harvesterhci.io server-version -o json | jq -r '.value')
+
+    # Check if version is empty
+    if [[ -z "$version" ]]; then
+        log_error "Failed to retrieve server version. Exiting Longhorn Backing Images check."
+        log_info "Longhorn-Backing-Images Test: Skipped"
+        echo -e "\n==============================\n"
+        return
+    fi
+    # If version is before v1.4.x, print a message and return
+    if [[ $version =~ ^v(1\.[0-3])\..* ]]; then
+        log_info "Current version ($version) is before v1.4.x. This check is not applicable."
+        log_info "Longhorn-Backing-Images Test: Skipped"
+        echo -e "\n==============================\n"
+        return
+    fi
+
     log_verbose "NOTE: This test will throw a warning if less than the default value and fail if minimum number of copies is set to 0."
     backingImageList=$(kubectl get backingImage -A  -o yaml | yq -r '.items[] | .metadata.name ')
     backingImageLowCount=$(kubectl get backingImage -A -ojsonpath='{.items[?(@.spec.minNumberOfCopies<3)].metadata.name}')


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
The upgrade helper was improved with the [Longhorn Backing Image check](https://github.com/harvester/upgrade-helpers/pull/25). However, Longhorn only supports backing image high availability (via the spec.minNumberOfCopies field) starting from Longhorn `v1.6.x` (corresponding to Harvester `v1.4.x`).


Additionally, this PR uses the yq command with the `-r` flag, which was introduced in [yq version 4.25](https://github.com/mikefarah/yq/pull/1245). However, the yq version bundled with `Harvester v1.3.2` is `v4.18`, which doesn’t support this flag:
```
# yq --version
yq (https://github.com/mikefarah/yq/) version 4.18.1

```

That’s why the upgrade helper encounters a check error when used with Harvester v1.3.2.

#### Solution:
**Check Harvester version before applying the backing image check.**
The backing image HA feature is only supported from Harvester **v1.4.0** onward. This change ensures the check is skipped for earlier versions to prevent errors.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8241

#### Test plan:
When executing the script from this PR on a Harvester **v1.3.2** control node, the backing image check issue should no longer be present.

#### Additional documentation or context
