### PR TITLE
Changes fetching controlplane nodes

### DIFF
--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -455,7 +455,7 @@ check_log_file()
 check_host()
 {
     log_info "Starting Host check... "
-    cp_nodes=$(kubectl get nodes |grep control-plane |awk '{ print $1 }')
+    cp_nodes=$(kubectl get nodes -l node-role.kubernetes.io/control-plane=true -o name | cut -d'/' -f2)
     log_verbose "The hostname is: $(hostname)"
     log_verbose "Controlplane nodes are:\n${cp_nodes}"
     log_verbose "The OS release is: $(awk -F= '$1=="PRETTY_NAME" { print $2 ;}' /etc/os-release)"
@@ -588,7 +588,7 @@ check_backup_target()
 }
 
 # This throws a warning if the minimum number of copies for a backing image is less than the default (3) 
-# Or if the minimum number of copies is set to '0' - it failes the test. VMs won't start if the backing image isn't available after upgrade. 
+# Or if the minimum number of copies is set to '0' - it fails the test. VMs won't start if the backing image isn't available after upgrade.
 check_images()
 {
     log_info "Starting Longhorn Backing Images check..."


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->
Not created an issue as I don't see an option to create one on this repo.

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Current approach to fetch the control plane nodes could even mark a node with `control-plane` in its name (not just its role) as a control-plane node. The node's role might have changed since its initial setup. Instead, listing the nodes matching the control plane label could ensure we don't get false positives.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
List nodes using label.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8359

#### Test plan:
<!-- Describe the test plan by steps. -->
NA

#### Additional documentation or context
NA