### PR TITLE
Update check.sh

### DIFF
--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -400,7 +400,7 @@ check_free_space()
                     continue
                 fi
 
-                stat_summary=$(curl -sk https://${node_ip}:${kubelet_port}/stats/summary -H "Authorization: Bearer ${token}" | jq .node.fs)
+                stat_summary=$(curl --noproxy '*' -sk https://${node_ip}:${kubelet_port}/stats/summary -H "Authorization: Bearer ${token}" | jq .node.fs)
                 used_bytes=$(echo "$stat_summary" | jq '.usedBytes')
                 capacity_bytes=$(echo "$stat_summary" | jq '.capacityBytes')
 


### PR DESCRIPTION
Added --noproxy '*' to the curl command to ignore a configured proxy. Internal networks are usually not reachable by HTTP proxies, therefore the call would fail.

I cannot create an issue, issues are disabled for this repo!

#### Problem:
The check script fails if a HTTP(S) proxy variable is set.

#### Solution:
Add --noproxy '*' to the curl command

#### Related Issue(s):
None

#### Test plan:
Set the variable https_proxy to something, doesn't matter what.
The original script will fail, the modified script will work.

#### Additional documentation or context
