### PR TITLE
Fix incorrect stale longhorn volume check in upgrade checker

### DIFF
--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -392,15 +392,15 @@ check_attached_volumes()
                 continue
             fi
 
-            # check .status.kubernetesStatus.workloadStatus has non-running workload. e.g.,
+            # check .status.kubernetesStatus.workloadStatus workloads are not running. e.g.,
             # workloadsStatus:
             #   - podName: virt-launcher-ubuntu-h9cfq
             #     podStatus: Succeeded
             #     workloadName: ubuntu
             #     workloadType: VirtualMachineInstance
-            is_stale=$(kubectl get volumes.longhorn.io/$vol_name -n $vol_namespace -o yaml | yq '.status.kubernetesStatus.workloadsStatus | any_c(.podStatus != "Running")')
-            if [ "$is_stale" = "true" ]; then
-                log_info "Volume ${vol_name} is attached, but one or more of its workloads is not running."
+            has_running_pod=$(kubectl get volumes.longhorn.io/$vol_name -n $vol_namespace -o yaml | yq '.status.kubernetesStatus.workloadsStatus | any_c(.podStatus == "Running")')
+            if [ "$has_running_pod" = "false" ]; then
+                log_info "Volume ${vol_name} is attached, but none of its workloads are running."
                 log_verbose "Details of the workloads:\n$(kubectl get volumes.longhorn.io/$vol_name -n $vol_namespace -o yaml | yq '.status.kubernetesStatus.workloadsStatus')"
                 rm -f $clean_state
             fi

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -392,12 +392,7 @@ check_attached_volumes()
                 continue
             fi
 
-            # check .status.kubernetesStatus.workloadStatus workloads are not running. e.g.,
-            # workloadsStatus:
-            #   - podName: virt-launcher-ubuntu-h9cfq
-            #     podStatus: Succeeded
-            #     workloadName: ubuntu
-            #     workloadType: VirtualMachineInstance
+            # check .status.kubernetesStatus.workloadStatus workloads are not running.
             has_running_pod=$(kubectl get volumes.longhorn.io/$vol_name -n $vol_namespace -o yaml | yq '.status.kubernetesStatus.workloadsStatus | any_c(.podStatus == "Running")')
             if [ "$has_running_pod" = "false" ]; then
                 log_info "Volume ${vol_name} is attached, but none of its workloads are running."

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -393,6 +393,24 @@ check_attached_volumes()
             fi
 
             # check .status.kubernetesStatus.workloadStatus workloads are not running.
+            # e.g. after a VM live migration, you'll see two workloads: the source pod (Succeeded)
+            # and the new pod (Running). In this case, the attached volume is NOT stale.
+            # kubernetesStatus:
+            #     lastPVCRefAt: ""
+            #     lastPodRefAt: ""
+            #     namespace: default
+            #     pvName: pvc-aa236e02-f114-48f9-897f-6016b5c3b61b
+            #     pvStatus: Bound
+            #     pvcName: test-disk-0-4soco
+            #     workloadsStatus:
+            #     - podName: virt-launcher-test-hxjtm
+            #     podStatus: Succeeded
+            #     workloadName: test
+            #     workloadType: VirtualMachineInstance
+            #     - podName: virt-launcher-test-qtcmt
+            #     podStatus: Running
+            #     workloadName: test
+            #     workloadType: VirtualMachineInstance
             has_running_pod=$(kubectl get volumes.longhorn.io/$vol_name -n $vol_namespace -o yaml | yq '.status.kubernetesStatus.workloadsStatus | any_c(.podStatus == "Running")')
             if [ "$has_running_pod" = "false" ]; then
                 log_info "Volume ${vol_name} is attached, but none of its workloads are running."

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -396,18 +396,18 @@ check_attached_volumes()
             # e.g. after a VM live migration, you'll see two workloads: the source pod (Succeeded)
             # and the new pod (Running). In this case, the attached volume is NOT stale.
             # kubernetesStatus:
-            #     lastPVCRefAt: ""
-            #     lastPodRefAt: ""
-            #     namespace: default
-            #     pvName: pvc-aa236e02-f114-48f9-897f-6016b5c3b61b
-            #     pvStatus: Bound
-            #     pvcName: test-disk-0-4soco
-            #     workloadsStatus:
-            #     - podName: virt-launcher-test-hxjtm
+            #   lastPVCRefAt: ""
+            #   lastPodRefAt: ""
+            #   namespace: default
+            #   pvName: pvc-aa236e02-f114-48f9-897f-6016b5c3b61b
+            #   pvStatus: Bound
+            #   pvcName: test-disk-0-4soco
+            #   workloadsStatus:
+            #   - podName: virt-launcher-test-hxjtm
             #     podStatus: Succeeded
             #     workloadName: test
-            #     workloadType: VirtualMachineInstance
-            #     - podName: virt-launcher-test-qtcmt
+            #   workloadType: VirtualMachineInstance
+            #   - podName: virt-launcher-test-qtcmt
             #     podStatus: Running
             #     workloadName: test
             #     workloadType: VirtualMachineInstance


### PR DESCRIPTION
#### Problem:
After VM live migration completes, an attached Longhorn volume still list pods in Succeeded state under `.status.kubernetesStatus.workloadsStatus`. This is harmless, but the current check treats it as an error and raises a false alarm.

#### Solution:
Change the script to ignore the attached volume which contain at least 1 running pod.



#### Related Issue(s):
https://github.com/harvester/harvester/issues/8974

#### Test plan:
1. start vm live migration. wait until migration finished.
2. run ./check.sh
3. no error output in the "Starting Stale Longhorn Volumes check..." section
```
==============================

Starting Stale Longhorn Volumes check...
Stale-Longhorn-Volumes Test: Pass

==============================
```

#### Additional documentation or context
