### PR TITLE
Fixed Prometheus check bug + added verification/remediation for cluster RKE2 certificate verification (v1.1.x script)

### DIFF
--- a/pre-check/v1.1.x/README.md
+++ b/pre-check/v1.1.x/README.md
@@ -30,18 +30,29 @@ We have developed a script to assist in verifying if a cluster is eligible for a
     All nodes are ready.
     >>> Check the CAPI cluster is provisioned...
     The CAPI cluster is provisioned.
+    >>> Check CAPI cluster is not paused...
+    CAPI cluster is not paused.
+    >>> Check the CAPI machines count...
+    CAPI machine count is equal to node count.
     >>> Check the CAPI machines are running...
     The CAPI machines are provisioned.
     >>> Check Longhorn volumes...
-    All volumes are healthy.
+    Skip checking for single node cluster.
     >>> Check stale Longhorn volumes...
-    Checking volume longhorn-system/pvc-c664716b-9e3a-4693-a91e-14ede2afb0cd...
-    Checking volume longhorn-system/pvc-ff113f82-702e-46ba-9c0c-bd11ece4ac33...
     There is no stale Longhorn volume.
     >>> Check error pods...
     All pods are OK.
-    All nodes have more than 30GB free space.
-    
+    Error from server (NotFound): services "rancher-monitoring-prometheus" not found
+    Error: no matches found
+    Prometheus service not found. Skipping free space check.
+    >>> Check control plane certificates...
+    >>> Checking kube-controller-manager certificate...
+    Certificate will not expire
+    kube-controller-manager certificate expires in 364 days (Apr 17 10:07:51 2027 GMT)
+    >>> Checking kube-scheduler certificate...
+    Certificate will not expire
+    kube-scheduler certificate expires in 364 days (Apr 17 10:07:51 2027 GMT)
+
     All checks pass.
     ```
 
@@ -51,4 +62,3 @@ We have developed a script to assist in verifying if a cluster is eligible for a
 ### Check time is in sync on every node.
 
 If there is no NTP server configured, please log in to each node and check the time is in sync (with `date` command).
-

--- a/pre-check/v1.1.x/check.sh
+++ b/pre-check/v1.1.x/check.sh
@@ -7,7 +7,6 @@ record_fail()
     check_failed=$((check_failed+1))
 }
 
-
 check_bundles()
 {
     echo ">>> Check all bundles ready..."
@@ -306,6 +305,12 @@ check_error_pods()
 check_free_space()
 {
     prom_ip=$(kubectl get services/rancher-monitoring-prometheus -n cattle-monitoring-system -o yaml | yq -e '.spec.clusterIP')
+
+    if [ -z "$prom_ip" ] || [ "$prom_ip" == "null" ]; then
+        echo "Prometheus service not found. Skipping free space check."
+        return
+    fi
+
     result=$(curl -sg "http://$prom_ip:9090/api/v1/query?query=node_filesystem_avail_bytes{mountpoint=\"/usr/local\"}<32212254720" | jq '.data.result')
 
     length=$(echo "$result" | jq 'length')
@@ -320,6 +325,48 @@ check_free_space()
     record_fail
 }
 
+# https://github.com/rancher/rancher/issues/41125#issuecomment-1506620040
+check_cert()
+{
+    local name=$1
+    local cert=$2
+
+    echo ">>> Checking $name certificate..."
+
+    if [ ! -f "$cert" ]; then
+        echo "Certificate not found: $cert"
+        record_fail
+        return
+    fi
+
+    if ! openssl x509 -checkend 0 -noout -in "$cert"; then
+        echo "$name certificate is EXPIRED!"
+        record_fail
+        return
+    fi
+
+    end_date=$(openssl x509 -enddate -noout -in "$cert" | cut -d= -f2)
+    end_epoch=$(date -d "$end_date" +%s)
+    now_epoch=$(date +%s)
+
+    seconds_left=$((end_epoch - now_epoch))
+    days_left=$((seconds_left / 86400))
+
+    echo "$name certificate expires in $days_left days ($end_date)"
+
+    if [ $days_left -lt 7 ]; then
+        echo "WARNING: $name certificate expires in less than 7 days!"
+    fi
+}
+
+check_control_plane_certificates()
+{
+    echo ">>> Check control plane certificates..."
+
+    check_cert "kube-controller-manager" "/var/lib/rancher/rke2/server/tls/kube-controller-manager/kube-controller-manager.crt"
+    check_cert "kube-scheduler" "/var/lib/rancher/rke2/server/tls/kube-scheduler/kube-scheduler.crt"
+}
+
 check_bundles
 check_harvester_bundle
 check_nodes
@@ -330,6 +377,7 @@ check_volumes
 check_attached_volumes
 check_error_pods
 check_free_space
+check_control_plane_certificates
 
 if [ $check_failed -gt 0 ]; then
     echo ""

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -9,7 +9,6 @@ usage() {
  echo " -y,     Assume 'y' to all answers and continue without asking."
 }
 
-
 while getopts "hvyl:" flag; do
  case $flag in
    h) # Handle the -h flag
@@ -40,7 +39,6 @@ done
 check_failed=0
 failed_check_name=''
 
-
 record_fail()
 {
     check_failed=$((check_failed+1))
@@ -69,7 +67,6 @@ log_info()
     echo -e "${1}"
 }
 
-
 HARVESTER_CLUSTER_VERSION=$(kubectl get settings.harvesterhci.io server-version -o json | jq -r '.value')
 echo "Upgrading from version $HARVESTER_CLUSTER_VERSION"
 
@@ -79,7 +76,6 @@ if [[ -z "$HARVESTER_CLUSTER_VERSION" ]]; then
     echo -e "\n==============================\n"
     return
 fi
-
 
 # Function necessary for version 1.4 of harvester cluster currently...
 # We should check if the Longhorn node has the EvictionRequested flag. If setted to true, will cause a Race Condition.
@@ -223,15 +219,11 @@ check_nodes()
         record_fail "Node-Status"
     fi
 
-
     # If version is 1.4.x, validate the Longhorn Eviction Requested status
     if [[ $HARVESTER_CLUSTER_VERSION =~ ^v(1.4)\..* ]]; then
         check_longhorn_eviction_status
     fi
-
-
 }
-
 
 check_cluster()
 {
@@ -712,7 +704,6 @@ check_virtual_machines_live_migration()
     log_info "Virtual Machines Test: Pass"
     echo -e "\n==============================\n"
 }
-
 
 check_log_file
 


### PR DESCRIPTION
Problem:
As Support Engineers, we often receive tickets from customers with issues during the upgrade process.

Sometimes the problem is that the underlying RKE2 cluster certificates have expired, but we don't realize it until the upgrade fails.

We thought it would be helpful to add this check as a pre-upgrade step.

Solution:
We added the check and fixed a small bug in the check_free_space check.

For the second point in particular, we were getting an error even if the kubectl command failed.

Related Issue(s):
Issue https://github.com/rancher/rancher/issues/41125#issuecomment-1506620040