### PR TITLE
fix: use prefix increment to avoid check.sh terminating

### DIFF
--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -180,7 +180,7 @@ check_nodes()
     for node_name in $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}'); do
         witness_annotation=$(kubectl get node "$node_name" -o json | jq -r '.metadata.labels."node-role.harvesterhci.io/witness"')
         if [ "$witness_annotation" = "true" ]; then
-            ((witness_amount++))
+            ((++witness_amount))
 
             # validate if there are at most 1 witness node
             if [[ "$witness_amount" -gt 1 ]]; then
@@ -477,7 +477,7 @@ check_free_space()
             log_info "Node \"${node_name}\" doesn't have enough free space."
             log_info "Used: $(awk -v used="$used_bytes" 'BEGIN {printf "%.2f", used/1024/1024/1024}') GB"
             log_info "Capacity: $(awk -v cap="$capacity_bytes" 'BEGIN {printf "%.2f", cap/1024/1024/1024}') GB"
-            (( disk_space_state++ ))
+            (( ++disk_space_state ))
         fi
     done
 


### PR DESCRIPTION
#### Problem:
check.sh runs with `#!/bin/bash -e`, i.e. the script will terminate if any pipeline exits with a non-zero status.  The usage of ((var++)) when applied to a var whose value is zero counts as a failed pipeline and kills the script.  This is because var++ is postfix increment, so it returns zero, which is translated to a failure.  No, I'm not joking. Try running check.sh on a cluster with a witness node.  You'll see this:
```
  # ./check.sh
  Upgrading from version v1.6.1
  ==============================

  Starting Host check...
  Host Test: Pass

  [...]

  ==============================

  Starting Node Status check...
```
And >clunk<, the script just terminates here.

#### Solution:
We can fix this by using prefix increment instead, which increments *before* returning and so counts as success.

#### Related Issue(s):
N/A
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
Run check.sh on a cluster with a witness node. Make sure it actually completes.

#### Additional documentation or context
