### PR TITLE
Add IP availability checks to upgrade preflight for storage and RWX networks

### DIFF
--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -730,6 +730,306 @@ check_virtual_machines_live_migration()
     echo -e "\n==============================\n"
 }
 
+# Get the effective Harvester setting value, or an empty string when unset.
+get_setting_effective_value()
+{
+    local setting_name=$1
+    local output
+
+    if ! output=$(kubectl get settings.harvesterhci.io "$setting_name" -o json); then
+        echo ""
+        return 0
+    fi
+
+    echo "$output" | jq -r '
+        (.value // "") as $value |
+        (.default // "") as $default |
+        if $value != "" then $value else $default end
+    '
+}
+
+# Convert an IPv4 address from dotted-decimal format to a 32-bit integer.
+ip_to_int()
+{
+    local ip=$1
+    local a b c d
+
+    IFS=. read -r a b c d <<< "$ip"
+    echo $(( (a * 2**24) + (b * 2**16) + (c * 2**8) + d ))
+}
+
+# Return the integer network bounds for an IPv4 CIDR range.
+# For example, cidr_bounds "192.168.1.10/24" returns <integer for 192.168.1.0> <integer for 192.168.1.255>
+cidr_bounds()
+{
+    local cidr=$1
+
+    # Extract IP and prefix using native Bash parameter expansion (faster than 'cut')
+    local ip="${cidr%/*}"
+    local prefix="${cidr#*/}"
+
+    # Validate that the prefix exists, is a number, and falls within the 0..32 IPv4 range
+    if [[ ! "$prefix" =~ ^[0-9]+$ ]] || [ "$prefix" -lt 0 ] || [ "$prefix" -gt 32 ]; then
+        echo "Error: Invalid CIDR prefix '$prefix'. Must be an integer between 0 and 32." >&2
+        return 1
+    fi
+
+    local ip_int=$(ip_to_int "$ip")
+
+    # Handle the /0 edge case safely to avoid an overflow with 2**32 in 32-bit math spaces
+    if [ "$prefix" -eq 0 ]; then
+        echo "0 4294967295"
+        return 0
+    fi
+
+    # Calculate the total number of IPs in the subnet block
+    local total=$(( 2**(32 - prefix) ))
+
+    # Divides the IP integer by the block size, truncates the remainder, then multiplies back.
+    # For 192.168.1.10/24, this gives the integer form of 192.168.1.0
+    local include_start=$(( (ip_int / total) * total ))
+    local include_end=$(( include_start + total - 1 ))
+
+    echo "$include_start $include_end"
+}
+
+# Count usable IPs in a CIDR range after excluding network, broadcast, and excluded ranges.
+get_usable_ip_count()
+{
+    local range=$1
+    shift
+    local excludes=("$@")
+    local include_start include_end exclude_start exclude_end overlap_start overlap_end count
+    local excluded_ranges=()
+    local merged_start merged_end start end
+
+    read -r include_start include_end < <(cidr_bounds "$range")
+    include_start=$(( include_start + 1 ))
+    include_end=$(( include_end - 1 ))
+
+    if (( include_end < include_start )); then
+        echo 0
+        return
+    fi
+
+    count=$(( include_end - include_start + 1 ))
+    for exclude in "${excludes[@]}"; do
+        read -r exclude_start exclude_end < <(cidr_bounds "$exclude")
+
+        overlap_start=$include_start
+        if (( exclude_start > overlap_start )); then
+            overlap_start=$exclude_start
+        fi
+
+        overlap_end=$include_end
+        if (( exclude_end < overlap_end )); then
+            overlap_end=$exclude_end
+        fi
+
+        if (( overlap_end >= overlap_start )); then
+            excluded_ranges+=("$overlap_start $overlap_end")
+        fi
+    done
+
+    if [ ${#excluded_ranges[@]} -eq 0 ]; then
+        echo "$count"
+        return
+    fi
+
+    merged_start=-1
+    merged_end=-1
+    while read -r start end; do
+        if (( merged_start == -1 )); then
+            merged_start=$start
+            merged_end=$end
+            continue
+        fi
+
+        if (( start <= merged_end + 1 )); then
+            if (( end > merged_end )); then
+                merged_end=$end
+            fi
+            continue
+        fi
+
+        count=$(( count - (merged_end - merged_start + 1) ))
+        merged_start=$start
+        merged_end=$end
+    done < <(printf '%s\n' "${excluded_ranges[@]}" | sort -n -k1,1 -k2,2)
+
+    count=$(( count - (merged_end - merged_start + 1) ))
+    echo "$count"
+}
+
+# Convert a CIDR range into the Whereabouts IPPool resource name.
+# This matches Whereabouts normalizeRange(): replace ":" and "/" with "-".
+# Examples:
+#   192.168.1.0/24  -> 192.168.1.0-24
+#   192.168.1.10/24 -> 192.168.1.10-24
+get_whereabouts_ippool_name()
+{
+    local range=$1
+
+    if [[ "$range" == *: ]]; then
+        range="${range}0"
+    fi
+    range=${range//:/-}
+    range=${range//\//-}
+
+    echo "$range"
+}
+
+# Count allocated IPs in the Whereabouts IPPool that matches the given CIDR range.
+get_whereabouts_allocation_count()
+{
+    local range=$1
+    local ippool_name
+
+    ippool_name=$(get_whereabouts_ippool_name "$range")
+    kubectl get ippools.whereabouts.cni.cncf.io "$ippool_name" -n kube-system -o json 2>/dev/null |
+        jq -r '.spec.allocations // {} | length'
+}
+
+# Count Longhorn instance managers.
+get_longhorn_instance_manager_count()
+{
+    kubectl get instancemanagers.longhorn.io -n longhorn-system -o json | jq -r '.items | length'
+}
+
+# Verify a network configuration has enough available IPs for the requested upgrade need.
+check_network_available_ips()
+{
+    local check_name=$1
+    local config_json=$2
+    local required=$3
+    local reason=$4
+    local range ippool_name allocation_count usable_count available_count
+    local excludes=()
+
+    range=$(echo "$config_json" | jq -r '.range // ""')
+    if [ -z "$range" ]; then
+        log_info "Cannot determine the IP range for $check_name."
+        record_fail "Network-IP-Availability"
+        return 1
+    fi
+
+    mapfile -t excludes < <(echo "$config_json" | jq -r '.exclude[]?')
+    usable_count=$(get_usable_ip_count "$range" "${excludes[@]}")
+    allocation_count=$(get_whereabouts_allocation_count "$range")
+    if [ -z "$allocation_count" ]; then
+        allocation_count=0
+    fi
+    available_count=$(( usable_count - allocation_count ))
+    ippool_name=$(get_whereabouts_ippool_name "$range")
+
+    if (( available_count < required )); then
+        log_info "$check_name has insufficient free IPs for upgrade."
+        log_info "Range: $range, Whereabouts IPPool: kube-system/$ippool_name, usable IPs: $usable_count, allocated IPs: $allocation_count, available IPs: $available_count, required free IPs: $required."
+        log_info "Required free IPs are for $reason. Expand the configured range, reduce excluded ranges, or free IPs used by workloads before upgrading."
+        record_fail "Network-IP-Availability"
+        return 1
+    fi
+
+    log_verbose "$check_name has enough free IPs: available=$available_count required=$required ($reason)."
+}
+
+# Determine if RWX shares the storage network.
+# v1.8+: read from rwx-network Harvester setting's share-storage-network field.
+# Pre-v1.8: read from Longhorn setting "Storage Network For RWX Volume Enabled".
+get_share_storage_network()
+{
+    local rwx_value=$1
+
+    # v1.8+: use the rwx-network Harvester setting.
+    if [ -n "$rwx_value" ]; then
+        echo "$rwx_value" | jq -r '."share-storage-network" // false'
+        return
+    fi
+
+    # Pre-v1.8 fallback: check the Longhorn boolean setting
+    # "Storage Network For RWX Volume Enabled".
+    local lh_rwx_enabled
+    lh_rwx_enabled=$(kubectl get settings.longhorn.io -n longhorn-system storage-network-for-rwx-volume-enabled -o jsonpath='{.value}' 2>/dev/null)
+    if [ "$lh_rwx_enabled" = "true" ]; then
+        echo "true"
+    else
+        echo "false"
+    fi
+}
+
+# Check that storage and RWX networks have enough free IPs before the upgrade starts.
+check_storage_rwx_network_ip_availability()
+{
+    log_info "Starting storage/RWX network IP availability check..."
+
+    local rwx_value storage_value share_storage_network rwx_network_json im_count checked=false
+
+    rwx_value=$(get_setting_effective_value "rwx-network")
+    if [ -z "$rwx_value" ]; then
+        log_info "rwx-network setting is only available on v1.8+ clusters. For older versions, the script will check the Longhorn setting 'Storage Network For RWX Volume Enabled' to determine if RWX shares the storage network."
+    fi
+    storage_value=$(get_setting_effective_value "storage-network")
+    share_storage_network=$(get_share_storage_network "$rwx_value")
+
+    # Error: shared mode but no storage network to share.
+    if [ "$share_storage_network" = "true" ] && [ -z "$storage_value" ]; then
+        log_info "rwx-network shares storage-network, but storage-network is empty."
+        record_fail "Network-IP-Availability"
+        return
+    fi
+
+    # Check storage network for Longhorn instance manager IPs.
+    # After the Longhorn upgrade manifest is applied, Longhorn creates a new
+    # set of instance manager pods (with the new image) before removing the old
+    # ones. The IM count doubles, and each new IM requires a fresh
+    # IP from the storage network. Therefore we must have at least im_count
+    # free IPs. If RWX shares this network, add one more for the temporary
+    # upgrade repository RWX volume.
+    if [ -n "$storage_value" ]; then
+        im_count=$(get_longhorn_instance_manager_count)
+        if [ -z "$im_count" ]; then
+            im_count=0
+        fi
+
+        if [ "$share_storage_network" = "true" ]; then
+            # Shared: upgrade repo IP also comes from storage network.
+            if ! check_network_available_ips "Shared storage/RWX network" "$storage_value" "$(( im_count + 1 ))" \
+                "1 upgrade repository RWX volume plus $im_count new Longhorn instance manager IPs"; then
+                return
+            fi
+            checked=true
+        elif [ "$im_count" -gt 0 ]; then
+            # Non-shared: just Longhorn instance manager IPs.
+            if ! check_network_available_ips "Storage network" "$storage_value" "$im_count" \
+                "$im_count new Longhorn instance manager IPs"; then
+                return
+            fi
+            checked=true
+        fi
+    fi
+
+    # Check dedicated RWX network for upgrade repository IP (non-shared only).
+    # The upgrade process creates a temporary RWX volume to serve the upgrade
+    # repository, which requires one free IP from the RWX network.
+    if [ -n "$rwx_value" ] && [ "$share_storage_network" != "true" ]; then
+        rwx_network_json=$(echo "$rwx_value" | jq -c '.network // empty')
+        if [ -n "$rwx_network_json" ]; then
+            if ! check_network_available_ips "Dedicated RWX network" "$rwx_network_json" 1 \
+                "1 upgrade repository RWX volume"; then
+                return
+            fi
+            checked=true
+        fi
+    fi
+
+    if [ "$checked" = "true" ]; then
+        log_info "Storage/RWX Network IP Availability Test: Pass"
+    else
+        log_info "Storage/RWX Network IP Availability Test: Skipped"
+    fi
+    echo -e "\n==============================\n"
+}
+
 # Needed to verify migration from wicked to NetworkManager will work.
 # Only applicable when upgrading from v1.6.x to v1.7.x
 check_network_config()
@@ -906,6 +1206,7 @@ check_virtual_machines_live_migration
 check_error_pods
 check_kubeconfig_secret
 check_backup_target
+check_storage_rwx_network_ip_availability
 
 if [[ $HARVESTER_CLUSTER_VERSION =~ ^v(1.6)\..* ]]; then
     check_network_config

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -909,13 +909,14 @@ check_network_available_ips()
     local config_json=$2
     local required=$3
     local reason=$4
+    local fail_check_name=${5:-Network-IP-Availability}
     local range ippool_name allocation_count usable_count available_count
     local excludes=()
 
     range=$(echo "$config_json" | jq -r '.range // ""')
     if [ -z "$range" ]; then
         log_info "Cannot determine the IP range for $check_name."
-        record_fail "Network-IP-Availability"
+        record_fail "$fail_check_name"
         return 1
     fi
 
@@ -932,7 +933,7 @@ check_network_available_ips()
         log_info "$check_name has insufficient free IPs for upgrade."
         log_info "Range: $range, Whereabouts IPPool: kube-system/$ippool_name, usable IPs: $usable_count, allocated IPs: $allocation_count, available IPs: $available_count, required free IPs: $required."
         log_info "Required free IPs are for $reason. Expand the configured range, reduce excluded ranges, or free IPs used by workloads before upgrading."
-        record_fail "Network-IP-Availability"
+        record_fail "$fail_check_name"
         return 1
     fi
 
@@ -963,81 +964,114 @@ get_share_storage_network()
     fi
 }
 
-# Check that storage and RWX networks have enough free IPs before the upgrade starts.
-check_storage_rwx_network_ip_availability()
+# Check the storage network for Longhorn instance manager and backing image manager IPs.
+# After the Longhorn upgrade manifest is applied, Longhorn creates a new
+# set of instance manager and backing image manager pods (with the new image)
+# before removing the old ones. Each new pod requires a fresh IP from the
+# storage network. Therefore we must have at least im_count + bim_count free
+# IPs. If RWX shares this network, add one more for the temporary upgrade
+# repository RWX volume.
+check_storage_network_ip_availability()
 {
-    log_info "Starting storage/RWX network IP availability check..."
+    log_info "Starting storage network IP availability check..."
 
-    local rwx_value storage_value share_storage_network rwx_network_json im_count bim_count storage_required checked=false
+    local rwx_value storage_value share_storage_network im_count bim_count storage_required
 
     rwx_value=$(get_setting_effective_value "rwx-network")
     if [ -z "$rwx_value" ]; then
         log_info "rwx-network setting is only available on v1.8+ clusters. For older versions, the script will check the Longhorn setting 'Storage Network For RWX Volume Enabled' to determine if RWX shares the storage network."
     fi
     storage_value=$(get_setting_effective_value "storage-network")
-    share_storage_network=$(get_share_storage_network "$rwx_value")
+    rwx_share_storage_network=$(get_share_storage_network "$rwx_value")
 
     # Error: shared mode but no storage network to share.
-    if [ "$share_storage_network" = "true" ] && [ -z "$storage_value" ]; then
+    if [ "$rwx_share_storage_network" = "true" ] && [ -z "$storage_value" ]; then
         log_info "rwx-network shares storage-network, but storage-network is empty."
-        record_fail "Network-IP-Availability"
+        record_fail "Storage-Network-IP-Availability"
         return
     fi
 
-    # Check storage network for Longhorn instance manager and backing image manager IPs.
-    # After the Longhorn upgrade manifest is applied, Longhorn creates a new
-    # set of instance manager and backing image manager pods (with the new image)
-    # before removing the old ones. Each new pod requires a fresh IP from the
-    # storage network. Therefore we must have at least im_count + bim_count free
-    # IPs. If RWX shares this network, add one more for the temporary upgrade
-    # repository RWX volume.
-    if [ -n "$storage_value" ] && [ "$storage_value" != "null" ]; then
-        im_count=$(get_longhorn_instance_manager_count)
-        if [ -z "$im_count" ]; then
-            im_count=0
-        fi
-        bim_count=$(get_longhorn_backing_image_manager_count)
-        if [ -z "$bim_count" ]; then
-            bim_count=0
-        fi
-        storage_required=$(( im_count + bim_count ))
-
-        if [ "$share_storage_network" = "true" ]; then
-            # Shared: upgrade repo IP also comes from storage network.
-            if ! check_network_available_ips "Shared storage/RWX network" "$storage_value" "$(( storage_required + 1 ))" \
-                "1 upgrade repository RWX volume plus $im_count new Longhorn instance manager IPs and $bim_count new Longhorn backing image manager IPs"; then
-                return
-            fi
-            checked=true
-        elif [ "$storage_required" -gt 0 ]; then
-            # Non-shared: just Longhorn manager pod replacement IPs.
-            if ! check_network_available_ips "Storage network" "$storage_value" "$storage_required" \
-                "$im_count new Longhorn instance manager IPs and $bim_count new Longhorn backing image manager IPs"; then
-                return
-            fi
-            checked=true
-        fi
+    if [ -z "$storage_value" ] || [ "$storage_value" = "null" ]; then
+        log_info "Storage Network IP Availability Test: Skipped"
+        echo -e "\n==============================\n"
+        return
     fi
 
-    # Check dedicated RWX network for upgrade repository IP (non-shared only).
-    # The upgrade process creates a temporary RWX volume to serve the upgrade
-    # repository, which requires one free IP from the RWX network.
-    if [ -n "$rwx_value" ] && [ "$share_storage_network" != "true" ]; then
-        rwx_network_json=$(echo "$rwx_value" | jq -c '.network // empty')
-        if [ -n "$rwx_network_json" ]; then
-            if ! check_network_available_ips "Dedicated RWX network" "$rwx_network_json" 1 \
-                "1 upgrade repository RWX volume"; then
-                return
-            fi
-            checked=true
+    im_count=$(get_longhorn_instance_manager_count)
+    if [ -z "$im_count" ]; then
+        im_count=0
+    fi
+    bim_count=$(get_longhorn_backing_image_manager_count)
+    if [ -z "$bim_count" ]; then
+        bim_count=0
+    fi
+    storage_required=$(( im_count + bim_count ))
+
+    if [ "$rwx_share_storage_network" = "true" ]; then
+        # Shared: upgrade repo IP also comes from storage network.
+        if ! check_network_available_ips "Storage network" "$storage_value" "$(( storage_required + 1 ))" \
+            "1 upgrade repository RWX volume plus $im_count new Longhorn instance manager IPs and $bim_count new Longhorn backing image manager IPs" \
+            "Storage-Network-IP-Availability"; then
+            return
         fi
+        log_info "Storage Network IP Availability Test: Pass"
+        echo -e "\n==============================\n"
+        return
     fi
 
-    if [ "$checked" = "true" ]; then
-        log_info "Storage/RWX Network IP Availability Test: Pass"
-    else
-        log_info "Storage/RWX Network IP Availability Test: Skipped"
+    if [ "$storage_required" -gt 0 ]; then
+        if ! check_network_available_ips "Storage network" "$storage_value" "$storage_required" \
+            "$im_count new Longhorn instance manager IPs and $bim_count new Longhorn backing image manager IPs" \
+            "Storage-Network-IP-Availability"; then
+            return
+        fi
+        log_info "Storage Network IP Availability Test: Pass"
+        echo -e "\n==============================\n"
+        return
     fi
+
+    log_info "Storage Network IP Availability Test: Skipped"
+    echo -e "\n==============================\n"
+}
+
+# Check the dedicated RWX network for upgrade repository IP (non-shared only).
+# The upgrade process creates a temporary RWX volume to serve the upgrade
+# repository, which requires one free IP from the RWX network.
+check_rwx_network_ip_availability()
+{
+    log_info "Starting RWX network IP availability check..."
+
+    local rwx_value share_storage_network
+    local rwx_network_json
+
+    rwx_value=$(get_setting_effective_value "rwx-network")
+    if [ -z "$rwx_value" ]; then
+        log_info "RWX network setting is empty. Dedicated RWX Network IP Availability Test: Skipped"
+        echo -e "\n==============================\n"
+        return
+    fi
+
+    share_storage_network=$(get_share_storage_network "$rwx_value")
+    if [ "$share_storage_network" = "true" ]; then
+        log_info "RWX network shares storage-network. Dedicated RWX Network IP Availability Test: Skipped"
+        echo -e "\n==============================\n"
+        return
+    fi
+
+    rwx_network_json=$(echo "$rwx_value" | jq -c '.network // empty')
+    if [ -z "$rwx_network_json" ]; then
+        log_info "RWX network setting does not define a dedicated network. Dedicated RWX Network IP Availability Test: Skipped"
+        echo -e "\n==============================\n"
+        return
+    fi
+
+    if ! check_network_available_ips "Dedicated RWX network" "$rwx_network_json" 1 \
+        "1 upgrade repository RWX volume" \
+        "RWX-Network-IP-Availability"; then
+        return
+    fi
+
+    log_info "Dedicated RWX Network IP Availability Test: Pass"
     echo -e "\n==============================\n"
 }
 
@@ -1217,7 +1251,8 @@ check_virtual_machines_live_migration
 check_error_pods
 check_kubeconfig_secret
 check_backup_target
-check_storage_rwx_network_ip_availability
+check_storage_network_ip_availability
+check_rwx_network_ip_availability
 
 if [[ $HARVESTER_CLUSTER_VERSION =~ ^v(1.6)\..* ]]; then
     check_network_config

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -896,6 +896,12 @@ get_longhorn_instance_manager_count()
     kubectl get instancemanagers.longhorn.io -n longhorn-system -o json | jq -r '.items | length'
 }
 
+# Count Longhorn backing image managers.
+get_longhorn_backing_image_manager_count()
+{
+    kubectl get backingimagemanagers.longhorn.io -n longhorn-system -o json 2>/dev/null | jq -r '.items | length'
+}
+
 # Verify a network configuration has enough available IPs for the requested upgrade need.
 check_network_available_ips()
 {
@@ -962,7 +968,7 @@ check_storage_rwx_network_ip_availability()
 {
     log_info "Starting storage/RWX network IP availability check..."
 
-    local rwx_value storage_value share_storage_network rwx_network_json im_count checked=false
+    local rwx_value storage_value share_storage_network rwx_network_json im_count bim_count storage_required checked=false
 
     rwx_value=$(get_setting_effective_value "rwx-network")
     if [ -z "$rwx_value" ]; then
@@ -978,30 +984,35 @@ check_storage_rwx_network_ip_availability()
         return
     fi
 
-    # Check storage network for Longhorn instance manager IPs.
+    # Check storage network for Longhorn instance manager and backing image manager IPs.
     # After the Longhorn upgrade manifest is applied, Longhorn creates a new
-    # set of instance manager pods (with the new image) before removing the old
-    # ones. The IM count doubles, and each new IM requires a fresh
-    # IP from the storage network. Therefore we must have at least im_count
-    # free IPs. If RWX shares this network, add one more for the temporary
-    # upgrade repository RWX volume.
-    if [ -n "$storage_value" ]; then
+    # set of instance manager and backing image manager pods (with the new image)
+    # before removing the old ones. Each new pod requires a fresh IP from the
+    # storage network. Therefore we must have at least im_count + bim_count free
+    # IPs. If RWX shares this network, add one more for the temporary upgrade
+    # repository RWX volume.
+    if [ -n "$storage_value" ] && [ "$storage_value" != "null" ]; then
         im_count=$(get_longhorn_instance_manager_count)
         if [ -z "$im_count" ]; then
             im_count=0
         fi
+        bim_count=$(get_longhorn_backing_image_manager_count)
+        if [ -z "$bim_count" ]; then
+            bim_count=0
+        fi
+        storage_required=$(( im_count + bim_count ))
 
         if [ "$share_storage_network" = "true" ]; then
             # Shared: upgrade repo IP also comes from storage network.
-            if ! check_network_available_ips "Shared storage/RWX network" "$storage_value" "$(( im_count + 1 ))" \
-                "1 upgrade repository RWX volume plus $im_count new Longhorn instance manager IPs"; then
+            if ! check_network_available_ips "Shared storage/RWX network" "$storage_value" "$(( storage_required + 1 ))" \
+                "1 upgrade repository RWX volume plus $im_count new Longhorn instance manager IPs and $bim_count new Longhorn backing image manager IPs"; then
                 return
             fi
             checked=true
-        elif [ "$im_count" -gt 0 ]; then
-            # Non-shared: just Longhorn instance manager IPs.
-            if ! check_network_available_ips "Storage network" "$storage_value" "$im_count" \
-                "$im_count new Longhorn instance manager IPs"; then
+        elif [ "$storage_required" -gt 0 ]; then
+            # Non-shared: just Longhorn manager pod replacement IPs.
+            if ! check_network_available_ips "Storage network" "$storage_value" "$storage_required" \
+                "$im_count new Longhorn instance manager IPs and $bim_count new Longhorn backing image manager IPs"; then
                 return
             fi
             checked=true

--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -730,15 +730,28 @@ check_virtual_machines_live_migration()
     echo -e "\n==============================\n"
 }
 
-# Get the effective Harvester setting value, or an empty string when unset.
+# Get the effective Harvester setting value.
+# When ignore_not_found is true, a missing setting returns an empty string.
+# Other kubectl errors are returned to the caller.
 get_setting_effective_value()
 {
     local setting_name=$1
+    local ignore_not_found=${2:-false}
     local output
 
-    if ! output=$(kubectl get settings.harvesterhci.io "$setting_name" -o json); then
-        echo ""
-        return 0
+    if [ "$ignore_not_found" = "true" ]; then
+        if ! output=$(kubectl get settings.harvesterhci.io "$setting_name" --ignore-not-found -o json); then
+            return 1
+        fi
+
+        if [ -z "$output" ]; then
+            echo ""
+            return 0
+        fi
+    else
+        if ! output=$(kubectl get settings.harvesterhci.io "$setting_name" -o json); then
+            return 1
+        fi
     fi
 
     echo "$output" | jq -r '
@@ -883,23 +896,38 @@ get_whereabouts_ippool_name()
 get_whereabouts_allocation_count()
 {
     local range=$1
-    local ippool_name
+    local ippool_name ippool_json
 
     ippool_name=$(get_whereabouts_ippool_name "$range")
-    kubectl get ippools.whereabouts.cni.cncf.io "$ippool_name" -n kube-system -o json 2>/dev/null |
-        jq -r '.spec.allocations // {} | length'
+    if ! ippool_json=$(kubectl get ippools.whereabouts.cni.cncf.io "$ippool_name" -n kube-system -o json); then
+        return 1
+    fi
+
+    echo "$ippool_json" | jq -r '.spec.allocations // {} | length'
 }
 
 # Count Longhorn instance managers.
 get_longhorn_instance_manager_count()
 {
-    kubectl get instancemanagers.longhorn.io -n longhorn-system -o json | jq -r '.items | length'
+    local output
+
+    if ! output=$(kubectl get instancemanagers.longhorn.io -n longhorn-system -o json); then
+        return 1
+    fi
+
+    echo "$output" | jq -r '.items | length'
 }
 
 # Count Longhorn backing image managers.
 get_longhorn_backing_image_manager_count()
 {
-    kubectl get backingimagemanagers.longhorn.io -n longhorn-system -o json 2>/dev/null | jq -r '.items | length'
+    local output
+
+    if ! output=$(kubectl get backingimagemanagers.longhorn.io -n longhorn-system -o json); then
+        return 1
+    fi
+
+    echo "$output" | jq -r '.items | length'
 }
 
 # Verify a network configuration has enough available IPs for the requested upgrade need.
@@ -922,9 +950,9 @@ check_network_available_ips()
 
     mapfile -t excludes < <(echo "$config_json" | jq -r '.exclude[]?')
     usable_count=$(get_usable_ip_count "$range" "${excludes[@]}")
-    allocation_count=$(get_whereabouts_allocation_count "$range")
-    if [ -z "$allocation_count" ]; then
-        allocation_count=0
+    if ! allocation_count=$(get_whereabouts_allocation_count "$range"); then
+        record_fail "$fail_check_name"
+        return 1
     fi
     available_count=$(( usable_count - allocation_count ))
     ippool_name=$(get_whereabouts_ippool_name "$range")
@@ -946,6 +974,7 @@ check_network_available_ips()
 get_share_storage_network()
 {
     local rwx_value=$1
+    local lh_rwx_enabled
 
     # v1.8+: use the rwx-network Harvester setting.
     if [ -n "$rwx_value" ]; then
@@ -955,8 +984,10 @@ get_share_storage_network()
 
     # Pre-v1.8 fallback: check the Longhorn boolean setting
     # "Storage Network For RWX Volume Enabled".
-    local lh_rwx_enabled
-    lh_rwx_enabled=$(kubectl get settings.longhorn.io -n longhorn-system storage-network-for-rwx-volume-enabled -o jsonpath='{.value}' 2>/dev/null)
+    if ! lh_rwx_enabled=$(kubectl get settings.longhorn.io -n longhorn-system storage-network-for-rwx-volume-enabled --ignore-not-found -o jsonpath='{.value}'); then
+        return 1
+    fi
+
     if [ "$lh_rwx_enabled" = "true" ]; then
         echo "true"
     else
@@ -975,14 +1006,23 @@ check_storage_network_ip_availability()
 {
     log_info "Starting storage network IP availability check..."
 
-    local rwx_value storage_value share_storage_network im_count bim_count storage_required
+    local rwx_value storage_value rwx_share_storage_network im_count bim_count storage_required
 
-    rwx_value=$(get_setting_effective_value "rwx-network")
+    if ! rwx_value=$(get_setting_effective_value "rwx-network" true); then
+        record_fail "Storage-Network-IP-Availability"
+        return
+    fi
     if [ -z "$rwx_value" ]; then
         log_info "rwx-network setting is only available on v1.8+ clusters. For older versions, the script will check the Longhorn setting 'Storage Network For RWX Volume Enabled' to determine if RWX shares the storage network."
     fi
-    storage_value=$(get_setting_effective_value "storage-network")
-    rwx_share_storage_network=$(get_share_storage_network "$rwx_value")
+    if ! storage_value=$(get_setting_effective_value "storage-network"); then
+        record_fail "Storage-Network-IP-Availability"
+        return
+    fi
+    if ! rwx_share_storage_network=$(get_share_storage_network "$rwx_value"); then
+        record_fail "Storage-Network-IP-Availability"
+        return
+    fi
 
     # Error: shared mode but no storage network to share.
     if [ "$rwx_share_storage_network" = "true" ] && [ -z "$storage_value" ]; then
@@ -997,13 +1037,13 @@ check_storage_network_ip_availability()
         return
     fi
 
-    im_count=$(get_longhorn_instance_manager_count)
-    if [ -z "$im_count" ]; then
-        im_count=0
+    if ! im_count=$(get_longhorn_instance_manager_count); then
+        record_fail "Storage-Network-IP-Availability"
+        return
     fi
-    bim_count=$(get_longhorn_backing_image_manager_count)
-    if [ -z "$bim_count" ]; then
-        bim_count=0
+    if ! bim_count=$(get_longhorn_backing_image_manager_count); then
+        record_fail "Storage-Network-IP-Availability"
+        return
     fi
     storage_required=$(( im_count + bim_count ))
 
@@ -1044,14 +1084,20 @@ check_rwx_network_ip_availability()
     local rwx_value share_storage_network
     local rwx_network_json
 
-    rwx_value=$(get_setting_effective_value "rwx-network")
+    if ! rwx_value=$(get_setting_effective_value "rwx-network" true); then
+        record_fail "RWX-Network-IP-Availability"
+        return
+    fi
     if [ -z "$rwx_value" ]; then
         log_info "RWX network setting is empty. Dedicated RWX Network IP Availability Test: Skipped"
         echo -e "\n==============================\n"
         return
     fi
 
-    share_storage_network=$(get_share_storage_network "$rwx_value")
+    if ! share_storage_network=$(get_share_storage_network "$rwx_value"); then
+        record_fail "RWX-Network-IP-Availability"
+        return
+    fi
     if [ "$share_storage_network" = "true" ]; then
         log_info "RWX network shares storage-network. Dedicated RWX Network IP Availability Test: Skipped"
         echo -e "\n==============================\n"


### PR DESCRIPTION
#### Problem:

see https://github.com/harvester/harvester/issues/10231

#### Solution:

Add IP availability checks to upgrade preflight for storage and RWX networks

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10231

#### Test plan:

Environment:
| Item | Value |
|------|-------|
| Cluster | 1-node Harvester |
| Longhorn | v1 + v2 enabled |
| Instance manager count | 2 (1 node x 2 engines) |
| LHv1 VMImage | 1 (1 backimagemanager pod) |
| Helper script | source [test-helpers.sh](https://gist.github.com/brandboat/058e363c0e6cf6ac039ae9ac8cbb2917) |

1. Setting up a test environment for this PR can be a bit tricky, so I’ve provided an example and some prerequisites above. These aren't strictly required, but they'll make verification much easier, otherwise calculating the IPs manually is a bit of a headache.
1. Please run run `source test-helpers.sh` before testing
1. You'll see `fake_alloc` in the test-helpers.sh, the reason we need this is because harvester webhook validates available IP count in the IPPool. Without pre-allocated fake IPs the pool has plenty of free addresses and every test would pass, `fake_alloc` simulates exhaustion to exercise the failure path.

<details>
<summary><h3>Full Test Plan</h3></summary>

## Test 1 — v1.7.x to v1.8.x check, enough IPs → PASS

Please prepare a v1.7.x single node harvester

**Goal:** When `rwx-network` is absent, fall back to Longhorn's `storage-network-for-rwx-volume-enabled`. If `true`, shared mode is used with sufficient free IPs.

**Setup:**
```bash
sto '{"clusterNetwork":"sn","range":"172.15.0.0/26"}'
lh_rwx true
wait_pods_ready
```

**Run:**
```bash
bash check.sh -y 2>&1 | grep -A6 "network IP availability check"
```

**Expected output:
```
harvester-node-0:~ # bash check.sh -y 2>&1 | grep -A6 "network IP availability check"
Starting storage network IP availability check...
Storage Network IP Availability Test: Pass

==============================

Starting RWX network IP availability check...
RWX network shares storage-network. Dedicated RWX Network IP Availability Test: Skipped

==============================
```

- available ips = 56 ≥ 4` (im_count 2 + 1 for upgrade repo + 1 bim pod)

**Cleanup:** `lh_rwx false`

---

## Test 2 — v1.7 to v1.8 check, NOT enough IPs → FAIL

Please prepare a v1.7 single node harvester

**Goal:** When `rwx-network` is absent, fall back to Longhorn's `storage-network-for-rwx-volume-enabled`. If `true`, shared mode is used. Exhausting the storage network triggers failure.

**Setup:**
```bash
sto '{"clusterNetwork":"sn","range":"172.15.0.0/26"}'
lh_rwx true
wait_pods_ready
fake_alloc "172.15.0.0/26" 58
```

**Run:**
```bash
bash check.sh -y 2>&1 | grep -A6 "network IP availability check"
```

**Expected:**
```
harvester-node-0:~ # bash check.sh -y 2>&1 | grep -A6 "network IP availability check"

Starting storage network IP availability check...
Storage network has insufficient free IPs for upgrade.
Range: 172.15.0.0/26, Whereabouts IPPool: kube-system/172.15.0.0-26, usable IPs: 62, allocated IPs: 62, available IPs: 0, required free IPs: 4.
Required free IPs are for 1 upgrade repository RWX volume plus 2 new Longhorn instance manager IPs and 1 new Longhorn backing image manager IPs. Expand the configured range, reduce excluded ranges, or free IPs used by workloads before upgrading.
Storage-Network-IP-Availability Test: Failed

==============================
--
Starting RWX network IP availability check...
RWX network shares storage-network. Dedicated RWX Network IP Availability Test: Skipped

==============================

WARN: There are 1 failing checks: Storage-Network-IP-Availability
```

- available ips = -2 < 4` (im_count 2 + 1 upgrade repo + 1 bim pod)

**Cleanup:**
```bash
clean_ippool "172.15.0.0/26"
lh_rwx false
```

---

## Test 3 — v1.8+ to latest version check, shared mode true, enough IPs → PASS

Please prepare a v1.8+ single node harvester

**Goal:** Shared storage/RWX network has sufficient free IPs.

**Setup:**
```bash
sto '{"clusterNetwork":"sn","range":"172.15.0.0/26"}'
rwx '{"share-storage-network":true}'
wait_pods_ready
```

**Run:**
```bash
bash check.sh -y 2>&1 | grep -A6 "network IP availability check"
```

**Expected output:
```
harvester-node-0:~ # bash check.sh -y 2>&1 | grep -A6 "network IP availability check"
Starting storage network IP availability check...
Storage Network IP Availability Test: Pass

==============================

Starting RWX network IP availability check...
RWX network shares storage-network. Dedicated RWX Network IP Availability Test: Skipped

==============================
```

- available ips = 56 ≥ 4 extra IPs during upgrade` (im_count 2 + 1 for upgrade repo + 1 bim pod)

---

## Test 4 — v1.8+ to latest version check, shared mode true, NOT enough IPs → FAIL

Please prepare a v1.8+ single node harvester

**Goal:** Shared network exhausted by fake allocations triggers failure.

**Setup:**
```bash
sto '{"clusterNetwork":"sn","range":"172.15.0.0/26"}'
rwx '{"share-storage-network":true}'
wait_pods_ready
fake_alloc "172.15.0.0/26" 58
```

**Run:**
```bash
bash check.sh -y 2>&1 | grep -A6 "network IP availability check"
```

**Expected:**
```
harvester-node-0:~ # bash check.sh -y 2>&1 | grep -A6 "network IP availability check"

Starting storage network IP availability check...
Storage network has insufficient free IPs for upgrade.
Range: 172.15.0.0/26, Whereabouts IPPool: kube-system/172.15.0.0-26, usable IPs: 62, allocated IPs: 62, available IPs: 0, required free IPs: 4.
Required free IPs are for 1 upgrade repository RWX volume plus 2 new Longhorn instance manager IPs and 1 new Longhorn backing image manager IPs. Expand the configured range, reduce excluded ranges, or free IPs used by workloads before upgrading.
Storage-Network-IP-Availability Test: Failed

==============================
--
Starting RWX network IP availability check...
RWX network shares storage-network. Dedicated RWX Network IP Availability Test: Skipped

==============================

WARN: There are 1 failing checks: Storage-Network-IP-Availability
```

- available ips = -2 < 4 extra IPs during upgrade` (im_count 2 + 1 upgrade repo + 1 bim pod)

**Cleanup:** `clean_ippool "172.15.0.0/26"`

---

## Test 5 — v1.8+ to latest version check, Non-shared mode, both networks pass → PASS

Please prepare a v1.8+ single node harvester

**Goal:** Storage and dedicated RWX networks each have enough IPs independently.

**Setup:**
```bash
sto '{"clusterNetwork":"sn","range":"172.15.0.0/26"}'
rwx '{"share-storage-network":false,"network":{"clusterNetwork":"sn","range":"172.16.0.0/26"}}'
wait_pods_ready
```

**Run:**
```bash
bash check.sh -y 2>&1 | grep -A6 "network IP availability check"
```

**Expected:**

```
harvester-node-0:~ # bash check.sh -y 2>&1 | grep -A6 "network IP availability check"
Starting storage network IP availability check...
Storage Network IP Availability Test: Pass

==============================

Starting RWX network IP availability check...
Dedicated RWX Network IP Availability Test: Pass

==============================

All checks have passed.
```

- storage network available IPs = 56 ≥ 4 extra IPs during upgrade (im_count 2 + 1 bim pod)
- RWX network available IPs = 62 ≥ 1 extra IP during upgrade (upgrade repo)

---

## Test 6 — v1.8+ to latest version check, Non-shared mode, RWX network fails → FAIL

Please prepare a v1.8+ single node harvester

**Goal:** Dedicated RWX network exhausted by fake allocations triggers failure.

**Setup:**
```bash
sto '{"clusterNetwork":"sn","range":"172.15.0.0/26"}'
rwx '{"share-storage-network":false,"network":{"clusterNetwork":"sn","range":"172.16.0.0/26"}}'
wait_pods_ready
fake_alloc "172.16.0.0/26" 62
```

**Run:**
```bash
bash check.sh -y 2>&1 | grep -A6 "network IP availability check"
```

**Expected:**
```
harvester-node-0:~ # bash check.sh -y 2>&1 | grep -A6 "network IP availability check"
Starting storage network IP availability check...
Storage Network IP Availability Test: Pass

==============================

Starting RWX network IP availability check...
Dedicated RWX network has insufficient free IPs for upgrade.
Range: 172.16.0.0/26, Whereabouts IPPool: kube-system/172.16.0.0-26, usable IPs: 62, allocated IPs: 63, available IPs: -1, required free IPs: 1.
Required free IPs are for 1 upgrade repository RWX volume. Expand the configured range, reduce excluded ranges, or free IPs used by workloads before upgrading.
RWX-Network-IP-Availability Test: Failed

==============================
```

- Storage network available IPs = 56 ≥ 3 extra IPs during upgrade (im_count 2 + 1 bim pod) → PASS
- RWX network available IPs = 0 < 1 (upgrade repo) → FAIL

**Cleanup:** `clean_ippool "172.16.0.0/26"`

---

## Test 7 — v1.8+ to latest version check, Exclude ranges (unordered, non-overlapping), enough IPs → PASS

Please prepare a v1.8+ single node harvester

**Goal:** Unordered exclude ranges are correctly sorted and merged; sufficient IPs remain.

**Setup:**
```bash
# Excludes listed out of order: /24 before /23
sto '{"clusterNetwork":"sn","range":"172.15.0.0/22","exclude":["172.15.2.0/24","172.15.0.0/23"]}'
rwx '{"share-storage-network":true}'
wait_pods_ready
```

**IP calculation:**
- `/22` total usable: 1022
- Exclude `/23` (172.15.0.0–172.15.1.255): 511 IPs overlap
- Exclude `/24` (172.15.2.0–172.15.2.255): 256 IPs overlap
- Adjacent after sort → merged: 511 + 256 = 767
- Usable: 1022 − 767 = **255**

**Run:**
```bash
bash check.sh -y 2>&1 | grep -A6 "network IP availability check"
```

**Expected:**

```
harvester-node-0:~ # bash check.sh -y 2>&1 | grep -A6 "network IP availability check"
Starting storage network IP availability check...
Storage Network IP Availability Test: Pass

==============================

Starting RWX network IP availability check...
Dedicated RWX Network IP Availability Test: Skipped

==============================

All checks have passed.
```

- Storage network available IPs = 249 ≥ 4 extra IPs during upgrade (im_count 2 + 1 upgrade repo + 1 bim pod)

---

## Test 8 — v1.8+ to latest version check, Exclude ranges (unordered) + fake_alloc → FAIL

Please prepare a v1.8+ single node harvester

**Goal:** Same unordered exclude setup, but fake allocations exhaust the usable pool.

**Setup:**
```bash
sto '{"clusterNetwork":"sn","range":"172.15.0.0/22","exclude":["172.15.2.0/24","172.15.0.0/23"]}'
rwx '{"share-storage-network":true}'
wait_pods_ready
fake_alloc "172.15.0.0/22" 252
```

**Run:**
```bash
bash check.sh -y 2>&1 | grep -A6 "network IP availability check"
```

**Expected:**
```
harvester-node-0:~ # bash check.sh -y 2>&1 | grep -A6 "network IP availability check"
Starting storage network IP availability check...
Storage network has insufficient free IPs for upgrade.
Range: 172.15.0.0/22, Whereabouts IPPool: kube-system/172.15.0.0-22, usable IPs: 255, allocated IPs: 256, available IPs: -1, required free IPs: 4.
Required free IPs are for 1 upgrade repository RWX volume plus 2 new Longhorn instance manager IPs and 1 new Longhorn backing image manager IPs. Expand the configured range, reduce excluded ranges, or free IPs used by workloads before upgrading.
Storage-Network-IP-Availability Test: Failed

==============================
--
Starting RWX network IP availability check...
RWX network shares storage-network. Dedicated RWX Network IP Availability Test: Skipped

==============================

WARN: There are 1 failing checks: Storage-Network-IP-Availability
```

- Storage network available IPs -1 < 4 (im_count 2 + 1 bim pod + 1 upgrade repo)

**Cleanup:** `clean_ippool "172.15.0.0/22"`

</details>

---

#### Additional documentation or context
