### PR TITLE
feat: add check for paused fleet-local/local CAPI cluster

### DIFF
--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -250,6 +250,23 @@ check_cluster()
     echo -e "\n==============================\n"
 }
 
+check_cluster_pause()
+{
+    log_info "Starting CAPI Cluster Pause check..."
+    cluster_paused=$(kubectl get clusters.cluster.x-k8s.io/local -n fleet-local -o yaml | yq '.spec.paused')
+
+    # cluster should not be paused
+    if [ "$cluster_paused" = "true" ]; then
+        log_info "CAPI cluster is paused. The upgrade will stall until 'spec.paused' is cleared on clusters.cluster.x-k8s.io/local in namespace fleet-local."
+        record_fail "CAPI-Cluster-Pause"
+        return
+    fi
+
+    log_verbose "The CAPI cluster is not paused."
+    log_info "CAPI-Cluster-Pause Test: Pass"
+    echo -e "\n==============================\n"
+}
+
 check_machines()
 {
     local failed="false"
@@ -880,6 +897,7 @@ check_bundles
 check_harvester_bundle
 check_nodes
 check_cluster
+check_cluster_pause
 check_machines
 check_volumes
 check_attached_volumes


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

harvester/harvester#10713

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Spin up a single-node v1.8.0 Harvester cluster
2. Pause the `local` CAPI cluster via `kubectl patch`
3. Run the pre-flight check script (with the correct KUBECONFIG)
4. The script should report back that the cluster has paused CAPI cluster

#### Additional documentation or context
