### PR TITLE
fix: use `exit` instead of `return` if harvester version check fails

### DIFF
--- a/pre-check/v1.x/check.sh
+++ b/pre-check/v1.x/check.sh
@@ -71,15 +71,15 @@ log_info()
 
 
 HARVESTER_CLUSTER_VERSION=$(kubectl get settings.harvesterhci.io server-version -o json | jq -r '.value')
-echo "Upgrading from version $HARVESTER_CLUSTER_VERSION"
 
 # Check if version is empty
 if [[ -z "$HARVESTER_CLUSTER_VERSION" ]]; then
     echo "Failed to retrieve server version. Exiting script check..."
     echo -e "\n==============================\n"
-    return
+    exit 1
 fi
 
+echo "Upgrading from version $HARVESTER_CLUSTER_VERSION"
 
 # Function necessary for version 1.4 of harvester cluster currently...
 # We should check if the Longhorn node has the EvictionRequested flag. If setted to true, will cause a Race Condition.


### PR DESCRIPTION
#### Problem:
If RKE2 isn't running or there's some other very weird failure early on, we'll see something like this:

  ```
  # /tmp/check.sh
  [...various errors here if rke2 isn't running...]
  Upgrading from version
  Failed to retrieve server version. Exiting script check...

  ==============================

  /tmp/check.sh: line 224: return: can only `return' from a function or sourced script
  ```

#### Solution:
The output is a bit nicer if we use `exit` instead of `return`, and move the "Upgrading from version" line to after the version check:
  ```
  # /tmp/check.sh
  [...various errors here if rke2 isn't running...]
  Failed to retrieve server version. Exiting script check...

  ==============================
  ```

#### Related Issue(s):
N/A

#### Test plan:
- Break access to k8s somehow (stop rke2, or run `export KUBECONFIG=/this-does-not-exist`)
- Run the check script and compare the outputs to those in the Problem and Solution listed above.

#### Additional documentation or context
